### PR TITLE
Refactor secondary service management and allow service deletion (geopyspark-driver part)

### DIFF
--- a/openeogeotrellis/GeotrellisCatalogImageCollection.py
+++ b/openeogeotrellis/GeotrellisCatalogImageCollection.py
@@ -16,6 +16,7 @@ import os
 
 from openeo.imagecollection import ImageCollection
 
+# TODO this is deprecated apparently: remove it?
 
 class GeotrellisCatalogImageCollection(ImageCollection):
 

--- a/openeogeotrellis/GeotrellisImageCollection.py
+++ b/openeogeotrellis/GeotrellisImageCollection.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, List, Union, Iterable, Tuple
 
 import geopyspark as gps
@@ -17,11 +18,13 @@ import uuid
 import pytz
 
 from openeo.imagecollection import ImageCollection
+from openeogeotrellis.service_registry import InMemoryServiceRegistry, WMTSService
 
+_log = logging.getLogger(__name__)
 
 class GeotrellisTimeSeriesImageCollection(ImageCollection):
 
-    def __init__(self, pyramid: Pyramid, service_registry, metadata: Dict = None):
+    def __init__(self, pyramid: Pyramid, service_registry: InMemoryServiceRegistry, metadata: Dict = None):
         self.pyramid = pyramid
         self.tms = None
         self._service_registry = service_registry
@@ -587,15 +590,17 @@ class GeotrellisTimeSeriesImageCollection(ImageCollection):
                 "bounds": level_bounds
             }
         else:
-            if ('wmts' in self.__dir__()):
-                self.wmts.stop()
+
             pysc = gps.get_spark_context()
 
             random_port = 0
             service_id = str(uuid.uuid4())
             wmts_base_url = os.getenv('WMTS_BASE_URL_PATTERN', 'http://openeo.vgt.vito.be/openeo/services/%s') % service_id
 
-            self.wmts = pysc._jvm.be.vito.eodata.gwcgeotrellis.wmts.WMTSServer.createServer(random_port, wmts_base_url)
+
+            # TODO: instead of storing in self, keep in a registry to allow cleaning up (wmts.stop)
+            wmts = pysc._jvm.be.vito.eodata.gwcgeotrellis.wmts.WMTSServer.createServer(random_port, wmts_base_url)
+            _log.info('Created WMTSServer: {w!s} ({u!s}, {p!r})'.format(w=wmts, u=wmts.getURI(), p=wmts.getPort()))
 
             if(kwargs.get("style") is not None):
                 max_zoom = self.pyramid.max_zoom
@@ -609,24 +614,27 @@ class GeotrellisTimeSeriesImageCollection(ImageCollection):
                 #color_map = gps.ColorMap.from_colors(breaks=[x for x in range(0,250)], color_list=gps.get_colors_from_matplotlib("YlGn"))
                 color_map = gps.ColorMap.build(histogram, matplotlib_name)
                 srdd_dict = {k: v.srdd.rdd() for k, v in self.pyramid.levels.items()}
-                self.wmts.addPyramidLayer("RDD", srdd_dict,color_map.cmap)
+                wmts.addPyramidLayer("RDD", srdd_dict,color_map.cmap)
             else:
                 srdd_dict = {k: v.srdd.rdd() for k, v in self.pyramid.levels.items()}
-                self.wmts.addPyramidLayer("RDD", srdd_dict)
+                wmts.addPyramidLayer("RDD", srdd_dict)
 
             import socket
+            # TODO what is this host logic about?
             host = [l for l in
                               ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1],
                                [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in
                                  [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]])
                               if l][0][0]
 
-            print(self.wmts.getURI())
-
-            self._service_registry.register(service_id, specification={
-                'type': type,
-                'process_graph': process_graph
-            }, host=host, port=self.wmts.getPort())
+            self._service_registry.register(WMTSService(
+                service_id=service_id,
+                specification={
+                    'type': type,
+                    'process_graph': process_graph
+                },
+                host=host, port=wmts.getPort(), server=wmts
+            ))
 
             return {
                 'type': 'WMTS',

--- a/openeogeotrellis/GeotrellisImageCollection.py
+++ b/openeogeotrellis/GeotrellisImageCollection.py
@@ -630,5 +630,6 @@ class GeotrellisTimeSeriesImageCollection(ImageCollection):
 
             return {
                 'type': 'WMTS',
-                'url': wmts_base_url + "/service/wmts"
+                'url': wmts_base_url + "/service/wmts",
+                'service_id': service_id
             }

--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -1,0 +1,66 @@
+from typing import List
+
+from openeo_driver import backend
+from openeogeotrellis import _service_registry
+from openeogeotrellis.service_registry import InMemoryServiceRegistry
+
+
+def _merge(original: dict, key, value) -> dict:
+    # TODO: move this to a more general module (e.g. openeo client)?
+    copy = dict(original)
+    copy[key] = value
+    return copy
+
+
+class GpsSecondaryServices(backend.SecondaryServices):
+    """Secondary Services implementation for GeoPySpark backend"""
+
+    def __init__(self, service_registry: InMemoryServiceRegistry = _service_registry):
+        self._service_registry = service_registry
+
+    def service_types(self) -> dict:
+        return {
+            "WMTS": {
+                "parameters": {
+                    "version": {
+                        "type": "string",
+                        "description": "The WMTS version to use.",
+                        "default": "1.0.0",
+                        "enum": [
+                            "1.0.0"
+                        ]
+                    }
+                },
+                "attributes": {
+                    "layers": {
+                        "type": "array",
+                        "description": "Array of layer names.",
+                        "example": [
+                            "roads",
+                            "countries",
+                            "water_bodies"
+                        ]
+                    }
+                }
+            }
+        }
+
+    def list_services(self) -> List[dict]:
+        return [
+            _merge(details, 'service_id', service_id)
+            for service_id, details in self._service_registry.get_all_specifications().items()
+        ]
+
+    def service_info(self, service_id: str) -> dict:
+        # TODO: add fields: id, url, enabled, parameters, attributes
+        details = self._service_registry.get_specification(service_id)
+        return _merge(details, 'service_id', service_id)
+
+    def remove_service(self, service_id: str) -> None:
+        self._service_registry.stop_service(service_id)
+
+
+def get_openeo_backend_implementation() -> backend.OpenEoBackendImplementation:
+    return backend.OpenEoBackendImplementation(
+        secondary_services=GpsSecondaryServices()
+    )

--- a/openeogeotrellis/job_tracker.py
+++ b/openeogeotrellis/job_tracker.py
@@ -11,6 +11,8 @@ from openeogeotrellis.job_registry import JobRegistry
 
 _log = logging.getLogger(__name__)
 
+# TODO: make this job tracker logic an internal implementation detail of JobRegistry?
+
 class JobTracker:
     class _UnknownApplicationIdException(ValueError):
         pass

--- a/openeogeotrellis/service_registry.py
+++ b/openeogeotrellis/service_registry.py
@@ -1,71 +1,106 @@
-from typing import Dict
-from kazoo.client import KazooClient, NoNodeError
-
+import contextlib
 import json
+import logging
+from typing import Dict
+
+from kazoo.client import KazooClient, NoNodeError
 
 from openeo_driver.errors import SecondaryServiceNotFound
 
+_log = logging.getLogger(__name__)
+
+
+class WMTSService:
+    """Container with information about running WMTS service."""
+    # TODO: move the whole `WMTSServer.createServer` creation part also into this class?
+    def __init__(self, service_id: str, specification: dict, host: str, port: int, server):
+        self.service_id = service_id
+        self.specification = specification
+        self.host = host
+        self.port = port
+        self.server = server
+
+    def stop(self):
+        self.server.stop()
+        # TODO: check if `.stop()` is enough (e.g. are all Spark RDDs and caches also released properly?)
+
+    def __str__(self):
+        return '{c}[{i}]@{h}:{p}({s})'.format(
+            c=self.__class__.__name__, i=self.service_id, h=self.host, p=self.port, s=self.server
+        )
+
 
 class InMemoryServiceRegistry:
-    """Keeps the mapping only in memory; Traefik will not be able to expose the service to the outside
-    world."""
+    """
+    Basic Service Registry that only keeps services in memory.
+    Traefik will not be able to expose the service to the outside world.
+    """
 
-    def __init__(self):
-        self._mapping = {}
+    def __init__(self, services: Dict[str, WMTSService] = None):
+        _log.info('Creating new {c}: {s}'.format(c=self.__class__.__name__, s=self))
+        self._services = services or {}
 
-    def register(self, service_id: str, specification: Dict, host: str, port: int):
-        service_info = {
-            'specification': specification
-        }
+    def register(self, service: WMTSService):
+        _log.info('Registering service {s}'.format(s=service))
+        self._services[service.service_id] = service
 
-        self._mapping[service_id] = service_info
+    def get_specification(self, service_id: str) -> dict:
+        return self._services[service_id].specification
 
-    def get(self, service_id) -> Dict:
-        return self._mapping[service_id]
+    def get_all_specifications(self) -> Dict[str, dict]:
+        return {sid: self.get_specification(sid) for sid in self._services.keys()}
 
-    def get_all(self) -> Dict[str, Dict]:
-        return self._mapping
+    def stop_service(self, service_id: str):
+        if service_id not in self._services:
+            raise SecondaryServiceNotFound(service_id)
+        service = self._services.pop(service_id)
+        _log.info('Stopping service {s}'.format(s=service))
+        service.stop()
 
 
-class ZooKeeperServiceRegistry:
+class ZooKeeperServiceRegistry(InMemoryServiceRegistry):
     """The idea is that 1) Traefik will use this to map an url to a port and 2) this application will use it
     to map ID's to service details (exposed in the API)."""
 
     def __init__(self):
+        super().__init__()
         self._root = '/openeo/services'
         # TODO: move these hosts to config, argument or constant?
         self._hosts = 'epod-master1.vgt.vito.be:2181,epod-master2.vgt.vito.be:2181,epod-master3.vgt.vito.be:2181'
         with self._zk_client() as zk:
             zk.ensure_path(self._root)
 
-    def register(self, service_id: str, specification: Dict, host: str, port: int):
-        with self._zk_client() as zk:
-            self._persist_details(zk, service_id, specification),
-            Traefik(zk).route(service_id, host, port)
+        # TODO: what about services that are defined in Zookeeper/Traefic but are already dead? Revive them? remove them?
+        #    More general: what is the point of persisting this if the service is lost when backend stops anyway?
 
-    def _persist_details(self, zk, service_id, specification):
+    def register(self, service: WMTSService):
+        super().register(service)
+        with self._zk_client() as zk:
+            self._persist_details(zk, service.service_id, service.specification),
+            Traefik(zk).route(service.service_id, service.host, service.port)
+
+    def _persist_details(self, zk: KazooClient, service_id: str, specification: dict):
         service_info = {
             'specification': specification
         }
-
         data = json.dumps(service_info).encode()
         zk.create(self._path(service_id), data)
 
     def _path(self, service_id):
         return self._root + "/" + service_id
 
-    def get(self, service_id) -> Dict:
+    def get_specification(self, service_id: str) -> dict:
         with self._zk_client() as zk:
             return self._load_details(zk, service_id)
 
-    def _load_details(self, zk: KazooClient, service_id):
+    def _load_details(self, zk: KazooClient, service_id: str):
         try:
             data, _ = zk.get(self._path(service_id))
         except NoNodeError:
             raise SecondaryServiceNotFound(service_id)
         return json.loads(data.decode())
 
-    def get_all(self) -> Dict[str, Dict]:
+    def get_all_specifications(self) -> Dict[str, dict]:
         with self._zk_client() as zk:
             service_ids = zk.get_children(self._root)
             return {service_id: self._load_details(zk, service_id) for service_id in service_ids}
@@ -76,6 +111,10 @@ class ZooKeeperServiceRegistry:
         zk.start()
         yield zk
         zk.stop()
+
+    def stop_service(self, service_id: str):
+        super().stop_service(service_id)
+        # TODO: also remove from zookeerer and Traefic
 
 
 class Traefik:

--- a/tests/test_service_registry.py
+++ b/tests/test_service_registry.py
@@ -1,0 +1,33 @@
+from unittest import mock
+
+import pytest
+
+from openeo_driver.errors import SecondaryServiceNotFound
+from openeogeotrellis import InMemoryServiceRegistry, WMTSService
+
+
+class TestInMemoryServiceRegistry:
+
+    def test_get_specification(self):
+        reg = InMemoryServiceRegistry()
+        service_id = 'sid-1234'
+        spec = {'process_graph': []}
+        server = mock.Mock()
+        reg.register(WMTSService(service_id, specification=spec, host='example.com', port=5678, server=server))
+        assert reg.get_specification(service_id) == spec
+        assert reg.get_all_specifications() == {service_id: spec}
+
+    def test_stop_service(self):
+        reg = InMemoryServiceRegistry()
+        service_id = 'sid-1234'
+        spec = {'process_graph': []}
+        server = mock.Mock()
+        reg.register(WMTSService(service_id, specification=spec, host='example.com', port=5678, server=server))
+        # Stop service
+        reg.stop_service(service_id)
+        server.stop.assert_called_with()
+        # service should be gone now
+        with pytest.raises(SecondaryServiceNotFound):
+            reg.get_specification(service_id)
+        with pytest.raises(SecondaryServiceNotFound):
+            reg.stop_service(service_id)


### PR DESCRIPTION
This is the geopyspark part of PR Open-EO/openeo-python-driver#10 to enable deletion of secondary services. Includes also a big refactor to address Open-EO/openeo-python-driver#8