### PR TITLE
EP-3005 Various spec compliancy fixes for collections metadata

### DIFF
--- a/layercatalog.json
+++ b/layercatalog.json
@@ -197,7 +197,7 @@
       }
     },
     "description": "Sentinel 1 GRD Sigma0, mosaic of all ascending relative orbits. Provided by Terrascope.",
-    "source": "Terrascope - VITO",
+    "providers": [{"name": "Terrascope/VITO"}],
     "license": "free",
     "extent": {
       "crs": "EPSG:3857",
@@ -260,7 +260,7 @@
       }
     },
     "description": "Sentinel 1 GRD Sigma0, mosaic of all descending relative orbits. Provided by Terrascope.",
-    "source": "Terrascope - VITO",
+    "providers": [{"name": "Terrascope/VITO"}],
     "license": "free",
     "extent": {
       "crs": "EPSG:3857",
@@ -324,7 +324,7 @@
       }
     },
     "description": "Sentinel 2 Level-2: Bottom-of-atmosphere reflectances in cartographic geometry, provided by Terrascope.",
-    "source": "Terrascope - VITO",
+    "providers": [{"name": "Terrascope/VITO"}],
     "license": "free",
     "extent": {
       "crs": "EPSG:3857",
@@ -410,7 +410,7 @@
       }
     },
     "description": "Sentinel 2 Level-3: fAPAR in Web Mercator projection, with overviews.",
-    "source": "Terrascope - VITO",
+    "providers": [{"name": "Terrascope/VITO"}],
     "license": "free",
     "extent": {
       "crs": "EPSG:3857",
@@ -441,7 +441,7 @@
       }
     },
     "description": "Sentinel 2 Level-3: fCOVER, web mercator projection, with overviews.",
-    "source": "Terrascope - VITO",
+    "providers": [{"name": "Terrascope/VITO"}],
     "license": "free",
     "extent": {
       "crs": "EPSG:3857",
@@ -522,7 +522,7 @@
         "data_id": "S2_SCENECLASSIFICATION_PYRAMID_20190624"
       }
     },
-    "source": "Terrascope - VITO",
+    "providers": [{"name": "Terrascope/VITO"}],
     "license": "free",
     "extent": {
       "crs": "EPSG:3857",
@@ -617,7 +617,7 @@
         "type": "sentinel-hub"
       }
     },
-    "source": "SentinelHub",
+    "providers": [{"name": "SentinelHub"}],
     "license": "free",
     "extent": {
       "crs": "EPSG:3857",

--- a/layercatalog.json
+++ b/layercatalog.json
@@ -5,7 +5,12 @@
     "product_id":"BIOPAR_FAPAR_V1_GLOBAL",
     "title": "Copernicus Global Land FAPAR product V1, 1km resolution, 10-daily",
     "description": "Global FAPAR at 1km resolution, 10-daily. The FAPAR quantifies the fraction of the solar radiation absorbed by live leaves for the photosynthesis activity. Then, it refers only to the green and alive elements of the canopy. The FAPAR depends on the canopy structure, vegetation element optical properties, atmospheric conditions, and angular configuration. To overcome this latter dependency, a daily integrated FAPAR value is assessed.\n\nFAPAR is recognized as an Essential Climate Variable (ECV) by the Global Climate Observing System (GCOS).",
-    "data_id":"BIOPAR_FAPAR_V1_GLOBAL",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "BIOPAR_FAPAR_V1_GLOBAL"
+      }
+    },
     "license": "free",
     "bands":["fapar"],
     "extent": {
@@ -31,7 +36,12 @@
     "product_id":"CGLS_FAPAR_V2_GLOBAL",
     "title": "Copernicus Global Land FAPAR product V2, 1km resolution, 10-daily",
     "description": "Global FAPAR at 1km resolution, 10-daily. The FAPAR quantifies the fraction of the solar radiation absorbed by live leaves for the photosynthesis activity. Then, it refers only to the green and alive elements of the canopy. The FAPAR depends on the canopy structure, vegetation element optical properties, atmospheric conditions, and angular configuration. To overcome this latter dependency, a daily integrated FAPAR value is assessed.\n\nFAPAR is recognized as an Essential Climate Variable (ECV) by the Global Climate Observing System (GCOS).",
-    "data_id":"BIOPAR_FAPAR_V2_GLOBAL",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "BIOPAR_FAPAR_V2_GLOBAL"
+      }
+    },
     "license": "free",
     "bands":["fapar"],
     "extent": {
@@ -57,7 +67,12 @@
     "product_id":"CGLS_LAI_V2_GLOBAL",
     "title": "Copernicus Global Land LAI product V2, 1km resolution, 10-daily",
     "description": "Global LAI at 1km resolution, 10-daily. The Leaf Area Index is defined as half the total area of green elements of the canopy per unit horizontal ground area. The satellite-derived value corresponds to the total green LAI of all the canopy layers, including the understory which may represent a very significant contribution, particularly for forests. Practically, the LAI quantifies the thickness of the vegetation cover.",
-    "data_id":"BIOPAR_LAI_V2_GLOBAL",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "BIOPAR_LAI_V2_GLOBAL"
+      }
+    },
     "license": "free",
     "bands":["fapar"],
     "extent": {
@@ -83,7 +98,12 @@
     "product_id":"CGLS_LAI300_V1_GLOBAL",
     "title": "Copernicus Global Land LAI product V2, 300m resolution, 10-daily",
     "description": "Global LAI at 300m resolution, 10-daily. The Leaf Area Index is defined as half the total area of green elements of the canopy per unit horizontal ground area. The satellite-derived value corresponds to the total green LAI of all the canopy layers, including the understory which may represent a very significant contribution, particularly for forests. Practically, the LAI quantifies the thickness of the vegetation cover.",
-    "data_id":"BIOPAR_LAI300_V1_GLOBAL",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "BIOPAR_LAI300_V1_GLOBAL"
+      }
+    },
     "license": "free",
     "bands":["lai"],
     "extent": {
@@ -109,7 +129,12 @@
     "product_id":"CGLS_NDVI300_V1_GLOBAL",
     "title": "Copernicus Global Land NDVI product V1, 300m resolution, 10-daily",
     "description": "Global NDVI at 300m resolution, 10-daily. The Normalized Difference Vegetation Index (NDVI) is an indicator of the greenness of the biomes. As such, it is closely linked to the FAPAR.",
-    "data_id":"BIOPAR_NDVI300_V1_GLOBAL",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "BIOPAR_NDVI300_V1_GLOBAL"
+      }
+    },
     "license": "free",
     "bands":["ndvi"],
     "extent": {
@@ -135,7 +160,12 @@
     "product_id":"CGLS_BA300_V1_GLOBAL",
     "title": "Copernicus Global Land burnt area product V1, 300m resolution, 10-daily",
     "description": "Global burnt area at 300m resolution, 10-daily. The Burnt Area product maps the burnt scars, and gives temporal information on the fire season. ",
-    "data_id":"BIOPAR_BA300_V1_GLOBAL",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "BIOPAR_BA300_V1_GLOBAL"
+      }
+    },
     "license": "free",
     "bands":["ba"],
     "extent": {
@@ -160,7 +190,12 @@
     "name": "S1_GRD_SIGMA0_ASCENDING",
     "product_id": "S1_GRD_SIGMA0_ASCENDING",
     "title": "Sentinel 1 GRD Sigma0 product, VV, VH and angle.",
-    "data_id": "S1_GRD_SIGMA0_ASCENDING_V110_ALL",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "S1_GRD_SIGMA0_ASCENDING_V110_ALL"
+      }
+    },
     "description": "Sentinel 1 GRD Sigma0, mosaic of all ascending relative orbits. Provided by Terrascope.",
     "source": "Terrascope - VITO",
     "license": "free",
@@ -218,7 +253,12 @@
     "name": "S1_GRD_SIGMA0_DESCENDING",
     "product_id": "S1_GRD_SIGMA0_DESCENDING",
     "title": "Sentinel 1 GRD Sigma0 product, VV, VH and angle.",
-    "data_id": "S1_GRD_SIGMA0_DESCENDING_V110_ALL-1548102680728_BACKUP",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "S1_GRD_SIGMA0_DESCENDING_V110_ALL-1548102680728_BACKUP"
+      }
+    },
     "description": "Sentinel 1 GRD Sigma0, mosaic of all descending relative orbits. Provided by Terrascope.",
     "source": "Terrascope - VITO",
     "license": "free",
@@ -277,7 +317,12 @@
     "name": "CGS_SENTINEL2_RADIOMETRY_V102_001",
     "product_id": "CGS_SENTINEL2_RADIOMETRY_V102_001",
     "title": "Sentinel 2 Bottom-of-atmosphere reflectances.",
-    "data_id": "CGS_SENTINEL2_RADIOMETRY_V102_EARLY",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "CGS_SENTINEL2_RADIOMETRY_V102_EARLY"
+      }
+    },
     "description": "Sentinel 2 Level-2: Bottom-of-atmosphere reflectances in cartographic geometry, provided by Terrascope.",
     "source": "Terrascope - VITO",
     "license": "free",
@@ -358,7 +403,12 @@
     "name":"S2_FAPAR_V102_WEBMERCATOR2",
     "product_id":"S2_FAPAR_V102_WEBMERCATOR2",
     "title": "10m fAPAR product based on Sentinel-2",
-    "data_id":"S2_FAPAR_PYRAMID_20190708",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "S2_FAPAR_PYRAMID_20190708"
+      }
+    },
     "description": "Sentinel 2 Level-3: fAPAR in Web Mercator projection, with overviews.",
     "source": "Terrascope - VITO",
     "license": "free",
@@ -384,7 +434,12 @@
     "name":"SENTINEL2_FCOVER_TERRASCOPE",
     "product_id":"SENTINEL2_FCOVER_TERRASCOPE",
     "title": "Sentinel 2 based fCover",
-    "data_id":"S2_FCOVER_PYRAMID_EARLY",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "S2_FCOVER_PYRAMID_EARLY"
+      }
+    },
     "description": "Sentinel 2 Level-3: fCOVER, web mercator projection, with overviews.",
     "source": "Terrascope - VITO",
     "license": "free",
@@ -402,12 +457,22 @@
   {
     "id": "SENTINEL2_NDVI_TERRASCOPE",
     "name": "SENTINEL2_NDVI_TERRASCOPE",
-    "data_id": "S2_NDVI_PYRAMID_EARLY"
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "S2_NDVI_PYRAMID_EARLY"
+      }
+    }
   },
   {
     "id": "SENTINEL2_LAI_TERRASCOPE",
     "name": "SENTINEL2_LAI_TERRASCOPE",
-    "data_id": "S2_LAI_PYRAMID_20190625"
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "S2_LAI_PYRAMID_20190625"
+      }
+    }
   },
 
   {
@@ -416,7 +481,12 @@
     "product_id":"PROBAV_L3_S10_TOC_NDVI_333M",
     "title": "300m NDVI, 10-daily cloud-free composite",
     "description": "300m NDVI, 10-daily cloud-free composite derived from PROBA-V data.",
-    "data_id":"PROBAV_L3_S10_TOC_NDVI_333M_V2",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "PROBAV_L3_S10_TOC_NDVI_333M_V2"
+      }
+    },
     "license": "free",
     "extent": {
       "crs": "EPSG:4326",
@@ -446,7 +516,12 @@
     "product_id": "S2_FAPAR_SCENECLASSIFICATION_V102_PYRAMID",
     "title": "Sen2Cor Scene Classification layer",
     "description": "Sen2Cor Scene Classification layer, from Sentinel 2 data.",
-    "data_id":"S2_SCENECLASSIFICATION_PYRAMID_20190624",
+    "_vito": {
+      "data_source": {
+        "type": "Accumulo",
+        "data_id": "S2_SCENECLASSIFICATION_PYRAMID_20190624"
+      }
+    },
     "source": "Terrascope - VITO",
     "license": "free",
     "extent": {
@@ -475,25 +550,27 @@
   {
     "id": "S2_NDVI_S3",
     "name": "S2_NDVI_S3",
-    "data_source": {
-      "type": "S3",
-      "endpoint": "http://oss.eu-west-0.prod-cloud-ocb.orange-business.com",
-      "region": "eu-west-0",
-      "bucket_name": "s2-ndvi"
-    },
     "bands":[],
     "title": "TerraScope test dataset on SoblooDias",
     "description": "NDVI",
-    "data_id":"S2_NDVI_S3",
+    "_vito": {
+      "data_source": {
+        "type": "S3",
+        "endpoint": "http://oss.eu-west-0.prod-cloud-ocb.orange-business.com",
+        "region": "eu-west-0",
+        "bucket_name": "s2-ndvi"
+      }
+    },
     "product_id":"S2_NDVI_S3",
-    "id":"S2_NDVI_S3",
     "license": "free"
   },
   {
     "id": "CGS_SENTINEL2_RADIOMETRY_V102_FILE",
     "name": "CGS_SENTINEL2_RADIOMETRY_V102_FILE",
-    "data_source": {
-      "type": "file"
+    "_vito": {
+      "data_source": {
+        "type": "file"
+      }
     },
     "bands": [
       { "band_id": "1" },
@@ -535,8 +612,10 @@
     "name": "SENTINEL1_GAMMA0_SENTINELHUB",
     "title": "Sentinel 1 Gamma0, 10m resolution, provided by SentinelHub",
     "description": "Global Sentinel 1 Gamma0, provided by SentinelHub. IW mode, VV and VH bands.",
-    "data_source": {
-      "type": "sentinel-hub"
+    "_vito": {
+      "data_source": {
+        "type": "sentinel-hub"
+      }
     },
     "source": "SentinelHub",
     "license": "free",

--- a/openeogeotrellis/GeotrellisImageCollection.py
+++ b/openeogeotrellis/GeotrellisImageCollection.py
@@ -78,7 +78,7 @@ class GeotrellisTimeSeriesImageCollection(ImageCollection):
         return self if self._data_source_type().lower() == 'file' else self.apply_to_levels(lambda rdd: rdd.bands(bands))
 
     def _data_source_type(self):
-        return self.metadata.get('data_source', {}).get('type', 'Accumulo')
+        return self.metadata.get('_vito', {}).get('data_source', {}).get('type', 'Accumulo')
 
     def date_range_filter(self, start_date: Union[str, datetime, date],end_date: Union[str, datetime, date]) -> 'ImageCollection':
         return self.apply_to_levels(lambda rdd: rdd.filter_by_times([pd.to_datetime(start_date),pd.to_datetime(end_date)]))

--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -48,7 +48,7 @@ class LayerCatalog:
 
         if hide_private:
             # Don't expose "private" fields
-            for key in (k for k in metadata.keys() if k.startswith('_')):
+            for key in [k for k in metadata.keys() if k.startswith('_')]:
                 del metadata[key]
 
         return metadata

--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -1,37 +1,65 @@
+import copy
 import json
+import warnings
 from pathlib import Path
-from typing import List, Dict
 
-import geopyspark as gps
+
+class UnknownCollectionException(ValueError):
+    # TODO move this to openeo package?
+    # TODO subclass from openeo base exception?
+    def __init__(self, collection_id):
+        super().__init__("Unknown collection {c!r}".format(c=collection_id))
 
 
 class LayerCatalog:
+    """Catalog describing the available image collections."""
 
-    """Catalog providing access to GeoPySpark layers"""
+    _stac_version = "0.7.0"
+
     def __init__(self, filename='layercatalog.json'):
         path = Path(filename)
         if not path.is_file():
-            raise RuntimeError("layercatalog.json not found, please make sure that it is available in the working directory.")
+            raise RuntimeError("LayerCatalog file not found: {f}".format(f=path))
 
         with path.open() as f:
             self.catalog = {layer["id"]: layer for layer in json.load(f)}
 
-    def layers(self) -> List:
+    def _normalize_layer_metadata(self, metadata: dict) -> dict:
+        """Make sure the layer metadata follows OpenEO spec to some extent."""
+        metadata = copy.deepcopy(metadata)
+
+        collection_id = metadata["id"]
+
+        # Make sure required fields are set.
+        metadata.setdefault("stac_version", self._stac_version)
+        metadata.setdefault("links", [])
+        metadata.setdefault("other_properties", {})
+        # Warn about missing fields where sensible defaults are not feasible
+        fallbacks = {
+            "description": "Description of {c} (#TODO)".format(c=collection_id),
+            "license": "proprietary",
+            "extent": {"spatial": [0, 0, 0, 0], "temporal": [None, None]},
+            "properties": {"cube:dimensions": {}},
+        }
+        for key, value in fallbacks.items():
+            if key not in metadata:
+                warnings.warn("Collection {c} is missing required metadata field {k!r}.".format(c=collection_id, k=key))
+            metadata[key] = value
+
+        key_blacklist = {"data_id"}
+        for key in key_blacklist:
+            metadata.pop(key, None)
+        return metadata
+
+    def assert_collection_id(self, collection_id):
+        if collection_id not in self.catalog:
+            raise UnknownCollectionException(collection_id)
+
+    def layers(self) -> list:
         """Returns all available layers."""
-        #TODO make this work with Kerberos authentication
-        return [LayerCatalog._clean_config(config)  for config in self.catalog.values()]
+        return [self._normalize_layer_metadata(m) for m in self.catalog.values()]
 
-    @classmethod
-    def _clean_config(cls, layer_config):
-        desired_keys = set(layer_config.keys()) - {"data_id"}
-        return {k:v for k,v in layer_config.items() if k in desired_keys}
-
-    def layer(self,product_id) -> Dict:
+    def layer(self, collection_id: str) -> dict:
         """Returns the layer config for a given id."""
-        if product_id in self.catalog:
-            return self.catalog[product_id]
-        else:
-            raise ValueError("Unknown collection id: " + product_id)
-
-
-
+        self.assert_collection_id(collection_id)
+        return self._normalize_layer_metadata(self.catalog[collection_id])

--- a/tests/test_apply_process.py
+++ b/tests/test_apply_process.py
@@ -83,7 +83,7 @@ class TestCustomFunctions(TestCase):
                 "wavelength_nm": 835.1
             }
         ],
-        "data_id": "CGS_SENTINEL2_RADIOMETRY_V101",
+        "_vito": {"accumulo_data_id": "CGS_SENTINEL2_RADIOMETRY_V101"},
         "description": "Sentinel 2 Level-2: Bottom-of-atmosphere reflectances in cartographic geometry",
         "extent": {
             "bottom": 39,

--- a/tests/test_apply_process.py
+++ b/tests/test_apply_process.py
@@ -93,7 +93,6 @@ class TestCustomFunctions(TestCase):
             "top": 71
         },
         "product_id": "CGS_SENTINEL2_RADIOMETRY_V101",
-        "source": "Terrascope - VITO",
         "time": {
             "from": "2016-01-01",
             "to": "2019-10-01"

--- a/tests/test_custom_functions.py
+++ b/tests/test_custom_functions.py
@@ -94,7 +94,6 @@ class TestCustomFunctions(TestCase):
             "top": 71
         },
         "product_id": "CGS_SENTINEL2_RADIOMETRY_V101",
-        "source": "Terrascope - VITO",
         "time": {
             "from": "2016-01-01",
             "to": "2019-10-01"

--- a/tests/test_custom_functions.py
+++ b/tests/test_custom_functions.py
@@ -84,7 +84,7 @@ class TestCustomFunctions(TestCase):
                 "wavelength_nm": 835.1
             }
         ],
-        "data_id": "CGS_SENTINEL2_RADIOMETRY_V101",
+        "_vito": {"accumulo_data_id": "CGS_SENTINEL2_RADIOMETRY_V101"},
         "description": "Sentinel 2 Level-2: Bottom-of-atmosphere reflectances in cartographic geometry",
         "extent": {
             "bottom": 39,


### PR DESCRIPTION
- add more normalization and sensible(?) defaults for required collection metadata fields
- move VITO specific metadata under "private" `_vito` field for better separation
- add initial `providers` field

addresses #10 