### PR TITLE
Extract better decoupled layer catalog (EP-3079)

### DIFF
--- a/openeogeotrellis/GeotrellisImageCollection.py
+++ b/openeogeotrellis/GeotrellisImageCollection.py
@@ -85,12 +85,13 @@ class GeotrellisTimeSeriesImageCollection(ImageCollection):
         return self.apply_to_levels(lambda rdd: rdd.filter_by_times([pd.to_datetime(start_date),pd.to_datetime(end_date)]))
 
     def filter_bbox(self, west, east, north, south, crs=None, base=None, height=None) -> 'ImageCollection':
-        # Note: the bbox is already extracted in `apply_process` and applied in `getImageCollection` through the viewingParameters
+        # Note: the bbox is already extracted in `apply_process` and applied in `GeoPySparkLayerCatalog.load_collection` through the viewingParameters
         return self
 
     def apply_pixel(self, bands:List, bandfunction) -> 'ImageCollection':
         """Apply a function to the given set of bands in this image collection."""
         #TODO apply .bands(bands)
+        #TODO deprecated
         return self.apply_to_levels(lambda rdd: rdd.convert_data_type(CellType.FLOAT64).map_cells(bandfunction))
 
     def apply(self, process:str, arguments = {}) -> 'ImageCollection':

--- a/openeogeotrellis/__init__.py
+++ b/openeogeotrellis/__init__.py
@@ -31,17 +31,6 @@ def get_backend_version() -> str:
     return __version__
 
 
-def health_check():
-    from pyspark import SparkContext
-    sc = SparkContext.getOrCreate()
-    count = sc.parallelize([1,2,3]).count()
-    return 'Health check: ' + str(count)
-
-
-
-
-
-
 def create_process_visitor():
     from .geotrellis_tile_processgraph_visitor import GeotrellisTileProcessGraphVisitor
     return GeotrellisTileProcessGraphVisitor()

--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -1,7 +1,9 @@
 from typing import List
 
 from openeo_driver import backend
+from openeo_driver.utils import read_json
 from openeogeotrellis import ConfigParams
+from openeogeotrellis.layercatalog import GeoPySparkLayerCatalog
 from openeogeotrellis.service_registry import InMemoryServiceRegistry, ZooKeeperServiceRegistry
 
 
@@ -66,6 +68,8 @@ def get_openeo_backend_implementation() -> backend.OpenEoBackendImplementation:
         InMemoryServiceRegistry() if ConfigParams().is_ci_context
         else ZooKeeperServiceRegistry()
     )
+    catalog = read_json("layercatalog.json")
     return backend.OpenEoBackendImplementation(
-        secondary_services=GpsSecondaryServices(service_registry=service_registry)
+        secondary_services=GpsSecondaryServices(service_registry=service_registry),
+        catalog=GeoPySparkLayerCatalog(all_metadata=catalog, service_registry=service_registry),
     )

--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -3,7 +3,7 @@ from typing import List
 from openeo_driver import backend
 from openeo_driver.utils import read_json
 from openeogeotrellis import ConfigParams
-from openeogeotrellis.layercatalog import GeoPySparkLayerCatalog
+from openeogeotrellis.layercatalog import GeoPySparkLayerCatalog, get_layer_catalog
 from openeogeotrellis.service_registry import InMemoryServiceRegistry, ZooKeeperServiceRegistry
 
 
@@ -70,10 +70,9 @@ class GeoPySparkBackendImplementation(backend.OpenEoBackendImplementation):
             InMemoryServiceRegistry() if ConfigParams().is_ci_context
             else ZooKeeperServiceRegistry()
         )
-        catalog = read_json("layercatalog.json")
         super().__init__(
             secondary_services=GpsSecondaryServices(service_registry=service_registry),
-            catalog=GeoPySparkLayerCatalog(all_metadata=catalog, service_registry=service_registry),
+            catalog=get_layer_catalog(service_registry=service_registry),
         )
 
     def health_check(self) -> str:

--- a/openeogeotrellis/configparams.py
+++ b/openeogeotrellis/configparams.py
@@ -1,13 +1,16 @@
 import os
 
+
 class ConfigParams:
 
     def __init__(self, env=os.environ):
-        self.zookeepernodes=env.get("ZOOKEEPERNODES",
-            'epod-master1.vgt.vito.be:2181,epod-master2.vgt.vito.be:2181,epod-master3.vgt.vito.be:2181'    
-        ).split(',') 
+        self.zookeepernodes = env.get(
+            "ZOOKEEPERNODES",
+            'epod-master1.vgt.vito.be:2181,epod-master2.vgt.vito.be:2181,epod-master3.vgt.vito.be:2181'
+        ).split(',')
 
         # Are we running in a unittest or continuous integration context?
         self.is_ci_context = any(v in env for v in ['TRAVIS', 'PYTEST_CURRENT_TEST'])
 
-
+        # TODO: can we avoid using env variables?
+        self.layer_catalog_metadata_files = env.get("OPENEO_CATALOG_FILES", "layercatalog.json").split(",")

--- a/openeogeotrellis/deploy/batch_job.py
+++ b/openeogeotrellis/deploy/batch_job.py
@@ -1,11 +1,13 @@
-import sys
 import json
+import sys
+from typing import Dict, List
+
 from pyspark import SparkContext
-from openeogeotrellis import kerberos
+
 from openeo import ImageCollection
 from openeo_driver import ProcessGraphDeserializer
-from openeo_driver.save_result import *
-from typing import Dict, List
+from openeo_driver.save_result import ImageCollectionResult, JSONResult
+from openeogeotrellis.utils import kerberos
 
 
 def _parse(job_specification_file: str) -> Dict:

--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -1,75 +1,131 @@
-import copy
-import json
-import warnings
-from pathlib import Path
-from typing import Union, List, Dict
+import logging
+
+import pytz
+from dateutil.parser import parse
+from geopyspark import TiledRasterLayer, LayerType
+from py4j.java_gateway import JavaGateway
+
+from openeo import ImageCollection, List
+from openeo.imagecollection import CollectionMetadata
+from openeo_driver.backend import CollectionCatalog
+from openeo_driver.utils import read_json
+from openeogeotrellis.GeotrellisImageCollection import GeotrellisTimeSeriesImageCollection
+from openeogeotrellis.configparams import ConfigParams
+from openeogeotrellis.service_registry import InMemoryServiceRegistry
+from openeogeotrellis.utils import kerberos
+
+logger = logging.getLogger(__name__)
 
 
-class UnknownCollectionException(ValueError):
-    # TODO move this to openeo package?
-    # TODO subclass from openeo base exception?
-    def __init__(self, collection_id):
-        super().__init__("Unknown collection {c!r}".format(c=collection_id))
+class GeoPySparkLayerCatalog(CollectionCatalog):
 
+    # TODO: eliminate the dependency/coupling with service registry
 
-class LayerCatalog:
-    """Catalog describing the available image collections."""
+    def __init__(self, all_metadata: List[dict], service_registry: InMemoryServiceRegistry):
+        super().__init__(all_metadata=all_metadata)
+        self._service_registry = service_registry
 
-    _stac_version = "0.7.0"
+    def _strip_private_metadata(self, d: dict) -> dict:
+        """Strip fields starting with underscore from a dictionary."""
+        return {k: v for (k, v) in d.items() if not k.startswith('_')}
 
-    def __init__(self, source: Union[str, List[dict], Dict[str, dict]] = 'layercatalog.json'):
-        if isinstance(source, (str, Path)):
-            path = Path(source)
-            if not path.is_file():
-                raise OSError("LayerCatalog file not found: {f}".format(f=path))
-            with path.open() as f:
-                source = json.load(f)
+    def get_all_metadata(self) -> List[dict]:
+        return [self._strip_private_metadata(d) for d in super().get_all_metadata()]
 
-        if isinstance(source, list) and all(isinstance(layer, dict) for layer in source):
-            self.catalog = {layer["id"]: layer for layer in source}
-        elif isinstance(source, dict) and all(isinstance(layer, dict) for layer in source.values()):
-            self.catalog = source.copy()
-        else:
-            raise ValueError("Don't know how to handle {s!r}".format(s=source))
-
-    def _normalize_layer_metadata(self, metadata: dict, hide_private=True) -> dict:
-        """Make sure the layer metadata follows OpenEO spec to some extent."""
-        metadata = copy.deepcopy(metadata)
-
-        collection_id = metadata["id"]
-
-        # Make sure required fields are set.
-        metadata.setdefault("stac_version", self._stac_version)
-        metadata.setdefault("links", [])
-        metadata.setdefault("other_properties", {})
-        # Warn about missing fields where sensible defaults are not feasible
-        fallbacks = {
-            "description": "Description of {c} (#TODO)".format(c=collection_id),
-            "license": "proprietary",
-            "extent": {"spatial": [0, 0, 0, 0], "temporal": [None, None]},
-            "properties": {"cube:dimensions": {}},
-        }
-        for key, value in fallbacks.items():
-            if key not in metadata:
-                warnings.warn("Collection {c} is missing required metadata field {k!r}.".format(c=collection_id, k=key))
-                metadata[key] = value
-
-        if hide_private:
-            # Don't expose "private" fields
-            for key in [k for k in metadata.keys() if k.startswith('_')]:
-                del metadata[key]
-
+    def get_collection_metadata(self, collection_id, strip_private=True) -> dict:
+        metadata = super().get_collection_metadata(collection_id)
+        if strip_private:
+            metadata = self._strip_private_metadata(metadata)
         return metadata
 
-    def assert_collection_id(self, collection_id):
-        if collection_id not in self.catalog:
-            raise UnknownCollectionException(collection_id)
+    def load_collection(self, collection_id: str, viewing_parameters: dict) -> ImageCollection:
+        logger.info("Creating layer for {c} with viewingParameters {v}".format(c=collection_id, v=viewing_parameters))
 
-    def layers(self) -> list:
-        """Returns all available layers."""
-        return [self._normalize_layer_metadata(m) for m in self.catalog.values()]
+        # TODO is it necessary to do this kerberos stuff here?
+        kerberos()
 
-    def layer(self, collection_id: str, hide_private=True) -> dict:
-        """Returns the layer config for a given id."""
-        self.assert_collection_id(collection_id)
-        return self._normalize_layer_metadata(self.catalog[collection_id], hide_private=hide_private)
+        layer_metadata = self.get_collection_metadata(collection_id, strip_private=False)
+        layer_source_info = layer_metadata.get("_vito", {}).get("data_source", {})
+        layer_source_type = layer_source_info.get("type", "Accumulo").lower()
+
+        import geopyspark as gps
+        from_date = normalize_date(viewing_parameters.get("from", None))
+        to_date = normalize_date(viewing_parameters.get("to", None))
+
+        left = viewing_parameters.get("left", None)
+        right = viewing_parameters.get("right", None)
+        top = viewing_parameters.get("top", None)
+        bottom = viewing_parameters.get("bottom", None)
+        srs = viewing_parameters.get("srs", None)
+        band_indices = viewing_parameters.get("bands")
+        pysc = gps.get_spark_context()
+        extent = None
+
+        gateway = JavaGateway(eager_load=True, gateway_parameters=pysc._gateway.gateway_parameters)
+        jvm = gateway.jvm
+        if (left is not None and right is not None and top is not None and bottom is not None):
+            extent = jvm.geotrellis.vector.Extent(float(left), float(bottom), float(right), float(top))
+
+        def accumulo_pyramid():
+            pyramidFactory = jvm.org.openeo.geotrellisaccumulo.PyramidFactory("hdp-accumulo-instance",
+                                                                              ','.join(ConfigParams().zookeepernodes))
+            accumulo_layer_name = layer_source_info['data_id']
+            return pyramidFactory.pyramid_seq(accumulo_layer_name, extent, srs, from_date, to_date)
+
+        def s3_pyramid():
+            endpoint = layer_source_info['endpoint']
+            region = layer_source_info['region']
+            bucket_name = layer_source_info['bucket_name']
+
+            return jvm.org.openeo.geotrelliss3.PyramidFactory(endpoint, region, bucket_name) \
+                .pyramid_seq(extent, srs, from_date, to_date)
+
+        def file_pyramid():
+            return jvm.org.openeo.geotrellis.file.Sentinel2RadiometryPyramidFactory() \
+                .pyramid_seq(extent, srs, from_date, to_date, band_indices)
+
+        def sentinel_hub_pyramid():
+            return jvm.org.openeo.geotrellis.file.Sentinel1Gamma0PyramidFactory() \
+                .pyramid_seq(extent, srs, from_date, to_date, band_indices)
+
+        if layer_source_type == 's3':
+            pyramid = s3_pyramid()
+        elif layer_source_type == 'file':
+            pyramid = file_pyramid()
+        elif layer_source_type == 'sentinel-hub':
+            pyramid = sentinel_hub_pyramid()
+        else:
+            pyramid = accumulo_pyramid()
+
+        temporal_tiled_raster_layer = jvm.geopyspark.geotrellis.TemporalTiledRasterLayer
+        option = jvm.scala.Option
+        levels = {pyramid.apply(index)._1(): TiledRasterLayer(LayerType.SPACETIME, temporal_tiled_raster_layer(
+            option.apply(pyramid.apply(index)._1()), pyramid.apply(index)._2())) for index in range(0, pyramid.size())}
+
+        image_collection = GeotrellisTimeSeriesImageCollection(
+            pyramid=gps.Pyramid(levels),
+            service_registry=self._service_registry,
+            metadata=CollectionMetadata(layer_metadata)
+        )
+        return image_collection.band_filter(band_indices) if band_indices else image_collection
+
+
+def normalize_date(date_string):
+    # TODO move this functionality to a more general utility module?
+    if date_string is not None:
+        date = parse(date_string)
+        if date.tzinfo is None:
+            date = date.replace(tzinfo=pytz.UTC)
+        return date.isoformat()
+    return None
+
+
+def get_default_layer_catalog(service_registry: InMemoryServiceRegistry = None):
+    """
+    Factory for default layer catalog
+    TODO can we eliminate the need for a default catalog with default json file??
+    """
+    return GeoPySparkLayerCatalog(
+        all_metadata=read_json("layercatalog.json"),
+        service_registry=service_registry or InMemoryServiceRegistry()
+    )

--- a/openeogeotrellis/utils.py
+++ b/openeogeotrellis/utils.py
@@ -1,3 +1,4 @@
+import collections
 import logging
 import os
 
@@ -40,3 +41,31 @@ def kerberos():
     # print(loginUser.hasKerberosCredentials())
     # currentUser.addCredentials(loginUser.getCredentials())
     # print(jvm.org.apache.hadoop.security.UserGroupInformation.getCurrentUser().hasKerberosCredentials())
+
+
+def dict_merge_recursive(a: dict, b: dict, overwrite=False) -> dict:
+    """
+    Merge two dictionaries recursively
+
+    :param a: first dictionary
+    :param b: second dictionary
+    :param overwrite: whether values of b can overwrite values of a
+    :return: merged dictionary
+
+    # TODO move this to utils module in openeo-python-driver or openeo-python-client?
+    """
+    # Start with shallow copy, we'll copy deeper parts where necessary through recursion.
+    result = a.copy()
+    for key, value in b.items():
+        if key in result:
+            if isinstance(value, collections.Mapping) and isinstance(result[key], collections.Mapping):
+                result[key] = dict_merge_recursive(result[key], value, overwrite=overwrite)
+            elif overwrite:
+                result[key] = value
+            elif result[key] == value:
+                pass
+            else:
+                raise ValueError("Can not automatically merge {a!r} and {b!r}".format(a=result[key], b=value))
+        else:
+            result[key] = value
+    return result

--- a/openeogeotrellis/utils.py
+++ b/openeogeotrellis/utils.py
@@ -1,0 +1,42 @@
+import logging
+import os
+
+from py4j.java_gateway import JavaGateway
+
+logger = logging.getLogger("openeo")
+
+
+def kerberos():
+    import geopyspark as gps
+
+    if 'HADOOP_CONF_DIR' not in os.environ:
+        logger.warn('HADOOP_CONF_DIR is not set. Kerberos based authentication will probably not be set up correctly.')
+
+    sc = gps.get_spark_context()
+    gateway = JavaGateway(gateway_parameters=sc._gateway.gateway_parameters)
+    jvm = gateway.jvm
+
+    hadoop_auth = jvm.org.apache.hadoop.conf.Configuration().get('hadoop.security.authentication')
+    if hadoop_auth != 'kerberos':
+        logger.warn('Hadoop client does not have hadoop.security.authentication=kerberos.')
+
+    currentUser = jvm.org.apache.hadoop.security.UserGroupInformation.getCurrentUser()
+    if currentUser.hasKerberosCredentials():
+        return
+    logger.info("Kerberos currentUser={u!r} isSecurityEnabled={s!r}".format(
+        u=currentUser.toString(), s=jvm.org.apache.hadoop.security.UserGroupInformation.isSecurityEnabled()
+    ))
+    # print(jvm.org.apache.hadoop.security.UserGroupInformation.getCurrentUser().getAuthenticationMethod().toString())
+
+    principal = sc.getConf().get("spark.yarn.principal")
+    sparkKeytab = sc.getConf().get("spark.yarn.keytab")
+    if principal is not None and sparkKeytab is not None:
+        jvm.org.apache.hadoop.security.UserGroupInformation.loginUserFromKeytab(principal, sparkKeytab)
+        jvm.org.apache.hadoop.security.UserGroupInformation.getCurrentUser().setAuthenticationMethod(
+            jvm.org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS)
+    # print(jvm.org.apache.hadoop.security.UserGroupInformation.getCurrentUser().toString())
+    # loginUser = jvm.org.apache.hadoop.security.UserGroupInformation.getLoginUser()
+    # print(loginUser.toString())
+    # print(loginUser.hasKerberosCredentials())
+    # currentUser.addCredentials(loginUser.getCredentials())
+    # print(jvm.org.apache.hadoop.security.UserGroupInformation.getCurrentUser().hasKerberosCredentials())

--- a/tests/data/layercatalog01.json
+++ b/tests/data/layercatalog01.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "FOO",
+    "license": "mit"
+  },
+  {
+    "id": "BAR",
+    "description": "bar",
+    "links": [
+      "example.com/bar"
+    ]
+  },
+  {
+    "id": "BZZ"
+  }
+]

--- a/tests/data/layercatalog02.json
+++ b/tests/data/layercatalog02.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "BAR",
+    "description": "The BAR layer"
+  },
+  {
+    "id": "FOO",
+    "license": "apache",
+    "links": [
+      "example.com/foo"
+    ]
+  },
+  {
+    "id": "QUU"
+  }
+]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+import pytest
+
+from openeogeotrellis.utils import dict_merge_recursive
+
+
+@pytest.mark.parametrize(["a", "b", "expected"], [
+    ({}, {}, {}),
+    ({1: 2}, {}, {1: 2}),
+    ({}, {1: 2}, {1: 2}),
+    ({1: 2}, {3: 4}, {1: 2, 3: 4}),
+    ({1: {2: 3}}, {1: {4: 5}}, {1: {2: 3, 4: 5}}),
+    ({1: {2: 3, 4: 5}, 6: 7}, {1: {8: 9}, 10: 11}, {1: {2: 3, 4: 5, 8: 9}, 6: 7, 10: 11}),
+    ({1: {2: {3: {4: 5, 6: 7}}}}, {1: {2: {3: {8: 9}}}}, {1: {2: {3: {4: 5, 6: 7, 8: 9}}}}),
+    ({1: {2: 3}}, {1: {2: 3}}, {1: {2: 3}})
+])
+def test_merge_recursive_default(a, b, expected):
+    assert dict_merge_recursive(a, b) == expected
+
+
+@pytest.mark.parametrize(["a", "b", "expected"], [
+    ({1: 2}, {1: 3}, {1: 3}),
+    ({1: 2, 3: 4}, {1: 5}, {1: 5, 3: 4}),
+    ({1: {2: {3: {4: 5}}, 6: 7}}, {1: {2: "foo"}}, {1: {2: "foo", 6: 7}}),
+    ({1: {2: {3: {4: 5}}, 6: 7}}, {1: {2: {8: 9}}}, {1: {2: {3: {4: 5}, 8: 9}, 6: 7}}),
+])
+def test_merge_recursive_overwrite(a, b, expected):
+    result = dict_merge_recursive(a, b, overwrite=True)
+    assert result == expected
+
+
+@pytest.mark.parametrize(["a", "b", "expected"], [
+    ({1: 2}, {1: 3}, {1: 3}),
+    ({1: "foo"}, {1: {2: 3}}, {1: {2: 3}}),
+    ({1: {2: 3}}, {1: "bar"}, {1: "bar"}),
+    ({1: "foo"}, {1: "bar"}, {1: "bar"}),
+])
+def test_merge_recursive_overwrite_conflict(a, b, expected):
+    with pytest.raises(ValueError):
+        result = dict_merge_recursive(a, b)
+    result = dict_merge_recursive(a, b, overwrite=True)
+    assert result == expected
+
+
+def test_merge_recursive_preserve_input():
+    a = {1: {2: 3}}
+    b = {1: {4: 5}}
+    result = dict_merge_recursive(a, b)
+    assert result == {1: {2: 3, 4: 5}}
+    assert a == {1: {2: 3}}
+    assert b == {1: {4: 5}}


### PR DESCRIPTION
companion PR for Open-EO/openeo-python-driver#20

- implements new Geopyspark specific CollectionCatalog from Open-EO/openeo-python-driver#20
- moves `getImageCollection` global function to `GeoPySparkLayerCatalog.load_collection`
- makes it possible to have alternative/multiple layer catalog JSON files (currently to be specified through env var `OPENEO_CATALOG_FILES`
- minor other tweaks along the way