### PR TITLE
GDD-917: Traefik: Add development endpoint

### DIFF
--- a/openeogeotrellis/traefik.py
+++ b/openeogeotrellis/traefik.py
@@ -39,7 +39,7 @@ class Traefik:
 
         # FIXME: a Path:/.well-known/openeo matcher is a better fit but that seems to require an additional "test" node
         if environment == 'dev':
-            match_openeo = "Host: openeo-dev.vgt.vito.be;PathPrefix: /openeo,/.well-known/openeo"
+            match_openeo = "Host: openeo-dev.vgt.vito.be,openeo-dev.vito.be;PathPrefix: /openeo,/.well-known/openeo"
             priority = 100
         else:
             match_openeo = "Host: openeo.vgt.vito.be,openeo.vito.be;PathPrefix: /openeo,/.well-known/openeo"


### PR DESCRIPTION
This commit configures the new development endpoint to prevent 'backend not found' issues when using the balanced public endpoint.

Signed-off-by: bjanssens <bjanssens@inuits.eu>