### PR TITLE
Add DEM layer with file-oscars type

### DIFF
--- a/layercatalog.json
+++ b/layercatalog.json
@@ -1306,12 +1306,15 @@
       "t": {"type": "temporal"},
       "bands": {
         "type": "bands",
-        "values": ["Copernicus_DSM_COG_10"]
+        "values": ["DEM"]
       }
     },
     "summaries": {
       "eo:bands": [
-        {"name": "Copernicus_DSM_COG_10"}
+        {
+          "name": "DEM",
+          "aliases": ["Copernicus_DSM_COG_10"]
+        }
       ]
     },
     "_vito": {

--- a/layercatalog.json
+++ b/layercatalog.json
@@ -1272,5 +1272,56 @@
         "native_crs": "EPSG:4326"
       }
     }
+  },
+  {
+    "id": "COP_DEM_GLO_30M_COG",
+    "name": "COP_DEM_GLO_30M_COG",
+    "title": "Copernicus DEM 30M COG",
+    "description": "Copernicus Global 30 meter Digital Elevation Model dataset in COG format.",
+    "license": "proprietary",
+    "providers": [
+      {
+          "name": "VITO, on behalf of the Belgian Science Policy Office (BELSPO).",
+          "roles":
+          [
+              "producer",
+              "licensor"
+          ],
+          "url": "https://terrascope.be"
+      }
+      ],
+    "links": [
+      {
+        "rel": "license",
+        "href": "https://spacedata.copernicus.eu/documents/20126/0/CSCDA_ESA_Mission-specific+Annex.pdf"
+      }
+    ],
+    "extent": {
+      "spatial": {"bbox": [[-180, -90, 180, 90]]},
+      "temporal": {"interval": [["2010-12-12", null]]}
+    },
+    "cube:dimensions": {
+      "x": {"type": "spatial", "axis": "x", "step": 0.002777777777777778, "reference_system": "EPSG:4326"},
+      "y": {"type": "spatial", "axis": "y", "step": 0.002777777777777778, "reference_system": "EPSG:4326"},
+      "t": {"type": "temporal"},
+      "bands": {
+        "type": "bands",
+        "values": ["Copernicus_DSM_COG_10"]
+      }
+    },
+    "summaries": {
+      "eo:bands": [
+        {"name": "Copernicus_DSM_COG_10"}
+      ]
+    },
+    "_vito": {
+      "data_source": {
+        "type": "file-oscars",
+        "opensearch_collection_id": "urn:eop:VITO:COP_DEM_GLO_30M_COG",
+        "opensearch_endpoint": "http://oscars-dev.vgt.vito.be",
+        "root_path": "/data/MTDA/DEM/COP_DEM_30M_COG",
+        "native_crs": "EPSG:4326"
+      }
+    }
   }
 ]

--- a/layercatalog.json
+++ b/layercatalog.json
@@ -1274,9 +1274,9 @@
     }
   },
   {
-    "id": "COP_DEM_GLO_30M_COG",
-    "name": "COP_DEM_GLO_30M_COG",
-    "title": "Copernicus DEM 30M COG",
+    "id": "COPERNICUS_30",
+    "name": "COPERNICUS_30",
+    "title": "Copernicus Global 30 meter Digital Elevation Model dataset.",
     "description": "Copernicus Global 30 meter Digital Elevation Model dataset in COG format.",
     "license": "proprietary",
     "providers": [

--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -176,6 +176,18 @@ class GeoPySparkLayerCatalog(CollectionCatalog):
                                                                                        experimental
                                                                                        ))
 
+        def file_oscars_pyramid():
+            return file_pyramid(lambda opensearch_endpoint, opensearch_collection_id, opensearch_link_titles, root_path:
+                                jvm.org.openeo.geotrellis.file.Sentinel2PyramidFactory(opensearch_endpoint,
+                                                                                       opensearch_collection_id,
+                                                                                       opensearch_link_titles,
+                                                                                       root_path,
+                                                                                       jvm.geotrellis.raster.CellSize(
+                                                                                           30.0,
+                                                                                           30.0),
+                                                                                       experimental
+                                                                                       ))
+
         def file_s5p_pyramid():
             return file_pyramid(jvm.org.openeo.geotrellis.file.Sentinel5PPyramidFactory)
 
@@ -352,6 +364,8 @@ class GeoPySparkLayerCatalog(CollectionCatalog):
             pyramid = file_cgls_pyramid()
         elif layer_source_type == 'file-agera5':
             pyramid = file_agera5_pyramid()
+        elif layer_source_type == 'file-oscars':
+            pyramid = file_oscars_pyramid()
         elif layer_source_type == 'creodias-s1-backscatter':
             pyramid = S1BackscatterOrfeo(jvm=jvm).creodias(
                 projected_polygons=projected_polygons_native_crs,


### PR DESCRIPTION
* Added COP_DEM_GLO_30M_COG layer to layercatalog.json
* Added the 'file-oscars' layer type which uses the Sentinel2PyramidFactory 
* Currently the file-oscars layer uses a static cell-size of (30,30) but this will later be pulled out of the cube:dimensions field based on the step size and reference system.