### PR TITLE
EP-3718 zonal_statistics: remove special case code path (single polygon timeseries)

### DIFF
--- a/tests/test_custom_functions.py
+++ b/tests/test_custom_functions.py
@@ -115,8 +115,8 @@ class TestCustomFunctions(TestCase):
     def test_polygon_series(self):
         polygon = Polygon([(0, 0), (0, 2), (2, 2), (2, 0), (0, 0)])
 
-        means = self.imagecollection_with_two_bands_and_one_date.polygonal_mean_timeseries(polygon)
-        assert means == {'2017-09-25T11:37:00Z': [[1.0, 2.0]]}
+        means = self.imagecollection_with_two_bands_and_one_date.zonal_statistics(regions=polygon, func="mean")
+        assert means.data == {'2017-09-25T11:37:00Z': [[1.0, 2.0]]}
 
     def _create_spacetime_layer(self, no_data):
         def tile(value):
@@ -157,5 +157,5 @@ class TestCustomFunctions(TestCase):
         input = self._create_spacetime_layer(no_data=-1.0)
         imagecollection = GeopysparkDataCube(pyramid=gps.Pyramid({0: input}))
         polygon = Polygon(shell=[(2.0, 6.0), (6.0, 6.0), (6.0, 2.0), (2.0, 2.0), (2.0, 6.0)])
-        means = imagecollection.polygonal_mean_timeseries(polygon)
-        assert means == {'2017-09-25T11:37:00Z': [[(0 + 0 + 0 + 0 + 1 + 1 + 1 + 1 + 2 + 2 + 2 + 2) / 12]]}
+        means = imagecollection.zonal_statistics(regions=polygon, func="mean")
+        assert means.data == {'2017-09-25T11:37:00Z': [[(0 + 0 + 0 + 0 + 1 + 1 + 1 + 1 + 2 + 2 + 2 + 2) / 12]]}


### PR DESCRIPTION
A special case code path (single polygon timeseries) seems to go wrong with certain tile cell types, giving wrong mean values.

In the calculation of `mean = sum / count`, the `sum` seems correct, but the `count` did sometimes include all pixels of the tile, instead of only the non-masked out ones.

This PR removes this special code path (polygonal_mean_timeseries) and simplifies the remaining code a bit

(ref: EP-3718)