### PR TITLE
EP-3819: add initial support for udfs with off-heap memory tiles

### DIFF
--- a/openeogeotrellis/deploy/submit_batch_job.sh
+++ b/openeogeotrellis/deploy/submit_batch_job.sh
@@ -105,7 +105,7 @@ spark-submit \
  --conf "spark.yarn.appMasterEnv.SPARK_HOME=$SPARK_HOME" --conf spark.yarn.appMasterEnv.PYTHON_EGG_CACHE=./ \
  --conf "spark.yarn.appMasterEnv.PYSPARK_PYTHON=$pysparkPython" \
  --conf "spark.executorEnv.PYSPARK_PYTHON=$pysparkPython" \
- --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64:/tmp_epod/gdal \
+ --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64:/tmp_epod/gdal:venv/lib64/python3.6/site-packages/jep \
  --conf spark.yarn.appMasterEnv.LD_LIBRARY_PATH=venv/lib64:/tmp_epod/gdal \
  --conf spark.executorEnv.PROJ_LIB=/tmp_epod/gdal/data --conf spark.yarn.appMasterEnv.PROJ_LIB=/tmp_epod/gdal/data \
  --conf spark.executorEnv.AWS_REGION=${AWS_REGION} --conf spark.yarn.appMasterEnv.AWS_REGION=${AWS_REGION} \

--- a/openeogeotrellis/deploy/submit_batch_job_spark24.sh
+++ b/openeogeotrellis/deploy/submit_batch_job_spark24.sh
@@ -107,7 +107,7 @@ spark-submit \
  --conf spark.dynamicAllocation.maxExecutors=${maxexecutors} \
  --conf "spark.yarn.appMasterEnv.SPARK_HOME=$SPARK_HOME" --conf spark.yarn.appMasterEnv.PYTHON_EGG_CACHE=./ \
  --conf "spark.yarn.appMasterEnv.PYSPARK_PYTHON=$pysparkPython" \
- --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64 \
+ --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64:venv/lib64/python3.6/site-packages/jep \
  --conf spark.yarn.appMasterEnv.LD_LIBRARY_PATH=venv/lib64 \
  --conf "spark.yarn.appMasterEnv.JAVA_HOME=/usr/lib/jvm/jre-11-openjdk" \
  --conf "spark.executorEnv.JAVA_HOME=/usr/lib/jvm/jre-11-openjdk" \

--- a/openeogeotrellis/geopysparkdatacube.py
+++ b/openeogeotrellis/geopysparkdatacube.py
@@ -512,7 +512,7 @@ class GeopysparkDataCube(DriverDataCube):
             _log.info(f"apply_tiles tilefunction result dims: {result_array.dims}")
             return (key,Tile(result_array.values, geotrellis_tile[1].cell_type,geotrellis_tile[1].no_data_value))
 
-        if runtime == 'PythonOffheap':
+        if runtime == 'Python-Jep':
             def rdd_function(openeo_metadata: GeopysparkCubeMetadata, rdd):
                 band_names = openeo_metadata.band_dimension.band_names
                 jvm = gps.get_spark_context()._jvm

--- a/openeogeotrellis/geopysparkdatacube.py
+++ b/openeogeotrellis/geopysparkdatacube.py
@@ -487,7 +487,7 @@ class GeopysparkDataCube(DriverDataCube):
         else:
             raise FeatureUnsupportedException(f"reduce_dimension with UDF along dimension {dimension} is not supported")
 
-    def apply_tiles(self, function, context={}) -> 'GeopysparkDataCube':
+    def apply_tiles(self, function, context={}, runtime="python") -> 'GeopysparkDataCube':
         """Apply a function to the given set of bands in this image collection."""
         #TODO apply .bands(bands)
 
@@ -512,12 +512,26 @@ class GeopysparkDataCube(DriverDataCube):
             _log.info(f"apply_tiles tilefunction result dims: {result_array.dims}")
             return (key,Tile(result_array.values, geotrellis_tile[1].cell_type,geotrellis_tile[1].no_data_value))
 
-        def rdd_function(openeo_metadata: GeopysparkCubeMetadata, rdd):
-            numpy_rdd = rdd.convert_data_type(CellType.FLOAT32).to_numpy_rdd().map(
-                log_memory(partial(tilefunction, rdd.layer_metadata, openeo_metadata))
-            )
-            metadata = GeopysparkDataCube._transform_metadata(rdd.layer_metadata, cellType=CellType.FLOAT32)
-            return gps.TiledRasterLayer.from_numpy_rdd(rdd.layer_type, numpy_rdd, metadata)
+        if runtime == 'PythonOffheap':
+            def rdd_function(openeo_metadata: GeopysparkCubeMetadata, rdd):
+                band_names = openeo_metadata.band_dimension.band_names
+                jvm = gps.get_spark_context()._jvm
+                udf = jvm.org.openeo.geotrellis.udf.Udf
+                result_layer = udf.runUserCode(function, rdd.srdd.rdd(), band_names, context)
+
+                temporal_tiled_raster_layer = jvm.geopyspark.geotrellis.TemporalTiledRasterLayer
+                option = jvm.scala.Option
+                return gps.TiledRasterLayer(
+                        gps.LayerType.SPACETIME,
+                        temporal_tiled_raster_layer(option.apply(rdd.zoom_level), result_layer)
+                    )
+        else:
+            def rdd_function(openeo_metadata: GeopysparkCubeMetadata, rdd):
+                numpy_rdd = rdd.convert_data_type(CellType.FLOAT32).to_numpy_rdd().map(
+                    log_memory(partial(tilefunction, rdd.layer_metadata, openeo_metadata))
+                )
+                metadata = GeopysparkDataCube._transform_metadata(rdd.layer_metadata, cellType=CellType.FLOAT32)
+                return gps.TiledRasterLayer.from_numpy_rdd(rdd.layer_type, numpy_rdd, metadata)
 
         return self.apply_to_levels(partial(rdd_function, self.metadata))
 

--- a/scripts/submit-batch-test.sh
+++ b/scripts/submit-batch-test.sh
@@ -43,7 +43,7 @@ spark-submit \
  --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=${pysparkPython} \
  --conf spark.yarn.appMasterEnv.PYSPARK_DRIVER_PYTHON=${pysparkPython} \
  --conf spark.executorEnv.PYSPARK_PYTHON=${pysparkPython} \
- --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64:/tmp_epod/gdal \
+ --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64:/tmp_epod/gdal:venv/lib64/python3.6/site-packages/jep \
  --conf spark.yarn.appMasterEnv.LD_LIBRARY_PATH=venv/lib64:/tmp_epod/gdal \
  --conf spark.executorEnv.PROJ_LIB=/tmp_epod/gdal/data \
  --conf spark.yarn.appMasterEnv.PROJ_LIB=/tmp_epod/gdal/data \

--- a/scripts/submit-local.sh
+++ b/scripts/submit-local.sh
@@ -39,7 +39,7 @@ spark-submit \
  --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=${pysparkPython} \
  --conf spark.yarn.appMasterEnv.PYSPARK_DRIVER_PYTHON=${pysparkPython} \
  --conf spark.executorEnv.PYSPARK_PYTHON=${pysparkPython} \
- --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64  \
+ --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64:venv/lib64/python3.6/site-packages/jep  \
  --conf spark.yarn.appMasterEnv.LD_LIBRARY_PATH=venv/lib64  \
  --conf spark.yarn.appMasterEnv.OPENEO_VENV_ZIP=${hdfsVenvZip} \
  --conf spark.yarn.appMasterEnv.WMTS_BASE_URL_PATTERN=http://openeo.vgt.vito.be/openeo/services/%s \

--- a/scripts/submit.sh
+++ b/scripts/submit.sh
@@ -37,7 +37,7 @@ spark-submit \
  --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=${pysparkPython} \
  --conf spark.yarn.appMasterEnv.PYSPARK_DRIVER_PYTHON=${pysparkPython} \
  --conf spark.executorEnv.PYSPARK_PYTHON=${pysparkPython} \
- --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64:/tmp_epod/gdal \
+ --conf spark.executorEnv.LD_LIBRARY_PATH=venv/lib64:/tmp_epod/gdal:venv/lib64/python3.6/site-packages/jep \
  --conf spark.yarn.appMasterEnv.LD_LIBRARY_PATH=venv/lib64:/tmp_epod/gdal \
  --conf spark.executorEnv.PROJ_LIB=/tmp_epod/gdal/data \
  --conf spark.yarn.appMasterEnv.PROJ_LIB=/tmp_epod/gdal/data \

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
         'Bottleneck==1.3.2',
         'python-json-logger',
         'rlguard-lib',
-        'openeo_udf',
         'jep==3.9.1'
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ setup(
         'Bottleneck==1.3.2',
         'python-json-logger',
         'rlguard-lib',
+        'openeo_udf',
+        'jep==3.9.1'
     ],
     extras_require={
         "dev": tests_require,


### PR DESCRIPTION
Add initial support for off-heap UDFs. Currently, normal UDFs will copy all tile data on spark worker nodes from JVM memory to Python and back. When this off-heap implementation is completed/optimized all tile data should reside in shared memory that is accessible by both Java and Python processes.

- Include runtime as a parameter when calling apply_tiles 
- Added PythonOffheap runtime which will execute the UDF using an initial version of offheap memory tiles (org.openeo.geotrellis.udf.Udf.runUserCode)  
- Added openeo_udf and JEP as dependencies 
- Added the path to libjep.so to LD_LIBRARY_PATH as this a runtime requirement for the JEP library (only on worker nodes)