### PR TITLE
Fix #126: use real user id in batch jobs instead of proxy user id

### DIFF
--- a/openeogeotrellis/deploy/batch_job.py
+++ b/openeogeotrellis/deploy/batch_job.py
@@ -225,23 +225,21 @@ def main(argv: List[str]) -> None:
     logger.info("argv: {a!r}".format(a=argv))
     logger.info("pid {p}; ppid {pp}; cwd {c}".format(p=os.getpid(), pp=os.getppid(), c=os.getcwd()))
 
-    if len(argv) < 6:
-        print("usage: %s "
-              "<job specification input file> <job directory> <results output file name> <user log file name> "
-              "<metadata file name> [api version] [dependencies]" % argv[0],
-              file=sys.stderr)
-        exit(1)
+    if len(argv) != 9:
+        raise Exception(
+            f"usage: {argv[0]} "
+            "<job specification input file> <job directory> <results output file name> <user log file name> "
+            "<metadata file name> <api version> <dependencies> <user id>"
+        )
 
     job_specification_file = argv[1]
     job_dir = Path(argv[2])
     output_file = job_dir / argv[3]
     log_file = job_dir / argv[4]
     metadata_file = job_dir / argv[5]
-    api_version = argv[6] if len(argv) >= 7 else None
-    dependencies = _deserialize_dependencies(argv[7]) if len(argv) >= 8 else {}
-    # TODO: do we still need proxy user id inside the batch job itself?
-    proxy_user_id = argv[8] if len(argv) >= 9 else None
-    user_id = argv[9] if len(argv) >= 10 else None
+    api_version = argv[6]
+    dependencies = _deserialize_dependencies(argv[7])
+    user_id = argv[8]
 
     _create_job_dir(job_dir)
 

--- a/openeogeotrellis/deploy/batch_job.py
+++ b/openeogeotrellis/deploy/batch_job.py
@@ -239,7 +239,9 @@ def main(argv: List[str]) -> None:
     metadata_file = job_dir / argv[5]
     api_version = argv[6] if len(argv) >= 7 else None
     dependencies = _deserialize_dependencies(argv[7]) if len(argv) >= 8 else {}
-    user_id = argv[8] if len(argv) >= 9 else None
+    # TODO: do we still need proxy user id inside the batch job itself?
+    proxy_user_id = argv[8] if len(argv) >= 9 else None
+    user_id = argv[9] if len(argv) >= 10 else None
 
     _create_job_dir(job_dir)
 

--- a/openeogeotrellis/deploy/submit_batch_job.sh
+++ b/openeogeotrellis/deploy/submit_batch_job.sh
@@ -134,4 +134,4 @@ spark-submit \
  --conf spark.yarn.tags=openeo \
  --jars "${extensions}","${backend_assembly}" \
  --name "${jobName}" \
- "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${proxyUser}"
+ "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${proxyUser}" "${userId}"

--- a/openeogeotrellis/deploy/submit_batch_job.sh
+++ b/openeogeotrellis/deploy/submit_batch_job.sh
@@ -134,4 +134,4 @@ spark-submit \
  --conf spark.yarn.tags=openeo \
  --jars "${extensions}","${backend_assembly}" \
  --name "${jobName}" \
- "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${proxyUser}" "${userId}"
+ "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${userId}"

--- a/openeogeotrellis/deploy/submit_batch_job_spark24.sh
+++ b/openeogeotrellis/deploy/submit_batch_job_spark24.sh
@@ -144,4 +144,4 @@ spark-submit \
  --conf spark.yarn.tags=openeo \
  --jars "${extensions}","${backend_assembly}" \
  --name "${jobName}" \
- "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${proxyUser}" "${userId}"
+ "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${userId}"

--- a/openeogeotrellis/deploy/submit_batch_job_spark24.sh
+++ b/openeogeotrellis/deploy/submit_batch_job_spark24.sh
@@ -144,4 +144,4 @@ spark-submit \
  --conf spark.yarn.tags=openeo \
  --jars "${extensions}","${backend_assembly}" \
  --name "${jobName}" \
- "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${proxyUser}"
+ "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${proxyUser}" "${userId}"

--- a/openeogeotrellis/deploy/submit_batch_job_spark3.sh
+++ b/openeogeotrellis/deploy/submit_batch_job_spark3.sh
@@ -165,4 +165,4 @@ spark-submit \
  --conf spark.yarn.tags=openeo \
  --jars "${extensions}","${backend_assembly}" \
  --name "${jobName}" \
- "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${proxyUser}"
+ "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${proxyUser}" "${userId}"

--- a/openeogeotrellis/deploy/submit_batch_job_spark3.sh
+++ b/openeogeotrellis/deploy/submit_batch_job_spark3.sh
@@ -165,4 +165,4 @@ spark-submit \
  --conf spark.yarn.tags=openeo \
  --jars "${extensions}","${backend_assembly}" \
  --name "${jobName}" \
- "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${proxyUser}" "${userId}"
+ "${main_py_file}" "$(basename "${processGraphFile}")" "${outputDir}" "${outputFileName}" "${userLogFileName}" "${metadataFileName}" "${apiVersion}" "${dependencies}" "${userId}"


### PR DESCRIPTION
see #126 

openEO processing in batch jobs needs real user id for `load_result` and UDPs to work properly.
Proxy user id is just necessary when submitting the job.