### PR TITLE
simplify propagating k8s job name

### DIFF
--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -1423,8 +1423,11 @@ class GpsBatchJobs(backend.BatchJobs):
                 jinja_template = Environment(
                     loader=FileSystemLoader(jinja_dir)
                 ).from_string(open(jinja_path).read())
+
+                spark_app_id = k8s_job_name(job_id=job_id, user_id=user_id)
+
                 rendered = jinja_template.render(
-                    job_name=k8s_job_name(job_id=job_id, user_id=user_id),
+                    job_name=spark_app_id,
                     job_specification=job_specification_file,
                     output_dir=output_dir,
                     output_file="out",
@@ -1468,7 +1471,6 @@ class GpsBatchJobs(backend.BatchJobs):
 
                 try:
                     submit_response = api_instance.create_namespaced_custom_object("sparkoperator.k8s.io", "v1beta2", "spark-jobs", "sparkapplications", dict_, pretty=True)
-                    spark_app_id = k8s_job_name(job_id=job_id, user_id=user_id)
                     logger.info(f"mapped job_id {job_id} to application ID {spark_app_id}", extra={'job_id': job_id})
                     dbl_registry.set_application_id(job_id, user_id, spark_app_id)
                     status_response = {}
@@ -2151,7 +2153,7 @@ class GpsBatchJobs(backend.BatchJobs):
                 version = "v1beta2"
                 namespace = "spark-jobs"
                 plural = "sparkapplications"
-                name = k8s_job_name(job_id=job_id, user_id=user_id)
+                name = application_id
                 logger.debug(f"Sending API call to kubernetes to delete job: {name}")
                 delete_response = api_instance.delete_namespaced_custom_object(group, version, namespace, plural, name)
                 logger.debug(

--- a/openeogeotrellis/integrations/kubernetes.py
+++ b/openeogeotrellis/integrations/kubernetes.py
@@ -26,6 +26,7 @@ def truncate_user_id_k8s(user_id: str) -> str:
 
 
 def k8s_job_name(job_id: str, user_id: str) -> str:
+    # TODO: shouldn't this be unique, like a YARN application ID, so that it resembles an "attempt" (think: restarting an OpenEO batch job)?
     user_id_truncated = truncate_user_id_k8s(user_id)
     job_id_truncated = truncate_job_id_k8s(job_id)
     return "job-{id}-{user}".format(id=job_id_truncated, user=user_id_truncated)

--- a/openeogeotrellis/job_tracker_v2.py
+++ b/openeogeotrellis/job_tracker_v2.py
@@ -27,7 +27,6 @@ from openeogeotrellis.backend import GpsBatchJobs, get_elastic_job_registry
 from openeogeotrellis.configparams import ConfigParams
 from openeogeotrellis.integrations.kubernetes import (
     K8S_SPARK_APP_STATE,
-    k8s_job_name,
     k8s_state_to_openeo_job_status,
     kube_client,
 )
@@ -151,8 +150,8 @@ class K8sStatusGetter(JobMetadataGetterInterface):
         self._kubecost_url = kubecost_url or "http://kubecost.kube-dev.vgt.vito.be/"
 
     def get_job_metadata(self, job_id: str, user_id: str, app_id: str) -> _JobMetadata:
-        job_status = self._get_job_status(job_id=job_id, user_id=user_id)
-        usage = self._get_usage(job_id=job_id, user_id=user_id)
+        job_status = self._get_job_status(app_id)
+        usage = self._get_usage(job_id, app_id)
         return _JobMetadata(
             status=job_status.status,
             start_time=job_status.start_time,
@@ -160,7 +159,7 @@ class K8sStatusGetter(JobMetadataGetterInterface):
             usage=usage,
         )
 
-    def _get_job_status(self, job_id: str, user_id: str) -> _JobMetadata:
+    def _get_job_status(self, application_id: str) -> _JobMetadata:
         # Local import to avoid kubernetes dependency when not necessary
         import kubernetes.client.exceptions
         try:
@@ -169,7 +168,7 @@ class K8sStatusGetter(JobMetadataGetterInterface):
                 version="v1beta2",
                 namespace="spark-jobs",
                 plural="sparkapplications",
-                name=k8s_job_name(job_id=job_id, user_id=user_id),
+                name=application_id,
             )
         except kubernetes.client.exceptions.ApiException as e:
             if e.status == 404:
@@ -191,12 +190,12 @@ class K8sStatusGetter(JobMetadataGetterInterface):
             status=job_status, start_time=start_time, finish_time=finish_time
         )
 
-    def _get_usage(self, job_id: str, user_id: str) -> Union[dict, None]:
+    def _get_usage(self, job_id: str, application_id: str) -> Union[dict, None]:
         try:
             url = url_join(self._kubecost_url, "/model/allocation")
             namespace = "spark-jobs"
             window = "5d"
-            pod = k8s_job_name(job_id=job_id, user_id=user_id) + "*"
+            pod = application_id + "*"
             params = (
                 ("aggregate", "namespace"),
                 ("filterNamespaces", namespace),


### PR DESCRIPTION
Would this change make sense?

AFAICT a k8s job name can be assembled only once and then persisted in the batch job metadata (`"application_id"`) like in the YARN case, so the propagation is explicit.

At the moment it's being assembled in several places so the propagation is implicit (reconstructed from `user_id` and `job_id`). You could say that it's "by convention" that this works.

This would simplify the code and in particular the job tracker a bit.

Also, semantically speaking I suppose this job name should be unique, like a YARN application ID, no? So in theory we could change it to a UUID and it would still work.