### PR TITLE
Issue72 openeo geotrellis extensions fix projection metadata missing

### DIFF
--- a/tests/deploy/test_batch_job.py
+++ b/tests/deploy/test_batch_job.py
@@ -348,36 +348,27 @@ def test_run_job(evaluate, tmp_path):
 def test_run_job_get_projection_extension_metadata(evaluate, tmp_path, monkeypatch):
     cube_mock = MagicMock()
 
-    job_dir = Path("./")
-    if not job_dir.exists():
-        job_dir.mkdir()
-    monkeypatch.chdir(job_dir)
+    job_dir = tmp_path / "job-test-proj-metadata"
+    job_dir.mkdir()
+    output_file = job_dir / "out"
+    metadata_file = job_dir / "metadata.json"
 
     first_asset_source = get_test_data_file(
-            "binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif"
+        "binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif"
     )
     first_asset_name = first_asset_source.name
     first_asset_dest = job_dir / first_asset_name
     shutil.copy(first_asset_source, first_asset_dest)
 
-    second_asset_file = job_dir / "tmp/openEO01-05.tif"
-    parent_dir = second_asset_file.parent
-    if not parent_dir.exists():
-        parent_dir.mkdir()
-
-    # Create an empty file so the file is at least present,
-    # even though its contents are invalid.
-    second_asset_file.write_bytes(b"")
-
     asset_meta = {
         first_asset_name: {
-            "href": first_asset_name,
+            "href": first_asset_name,  # A path relative to the job dir must work.
             "roles": "data",
         },
         # The second file does not exist on the filesystem.
         # This triggers that the projection extension metadata is put on the
         # bands, for the remaining assets (Here there is only 1 other asset off course).
-        "openEO01-05.tif": {"href": "tmp/openEO01-05.tif", "roles": "data"},
+        "openEO01-05.tif": {"href": "openEO01-05.tif", "roles": "data"},
     }
     cube_mock.write_assets.return_value = asset_meta
     evaluate.return_value = ImageCollectionResult(
@@ -400,8 +391,8 @@ def test_run_job_get_projection_extension_metadata(evaluate, tmp_path, monkeypat
         job_specification={
             "process_graph": {"nop": {"process_id": "discard_result", "result": True}}
         },
-        output_file=tmp_path / "out",
-        metadata_file=tmp_path / "metadata.json",
+        output_file=output_file,
+        metadata_file=metadata_file,
         api_version="1.0.0",
         job_dir=job_dir,
         dependencies={},
@@ -409,7 +400,7 @@ def test_run_job_get_projection_extension_metadata(evaluate, tmp_path, monkeypat
     )
 
     cube_mock.write_assets.assert_called_once()
-    metadata_result = read_json(tmp_path / "metadata.json")
+    metadata_result = read_json(metadata_file)
     assert metadata_result == {
         "assets": {
             first_asset_name: {
@@ -419,7 +410,7 @@ def test_run_job_get_projection_extension_metadata(evaluate, tmp_path, monkeypat
                 "proj:epsg": 4326,
                 "proj:shape": [720, 1188],
             },
-            "openEO01-05.tif": {"href": "tmp/openEO01-05.tif", "roles": "data"},
+            "openEO01-05.tif": {"href": "openEO01-05.tif", "roles": "data"},
         },
         "bbox": None,
         "end_datetime": None,

--- a/tests/deploy/test_batch_job.py
+++ b/tests/deploy/test_batch_job.py
@@ -463,23 +463,32 @@ def test_run_job_get_projection_extension_metadata_all_assets_same_epsg_and_bbox
     """
     cube_mock = MagicMock()
 
-    first_asset_path = get_test_data_file(
+    job_dir = tmp_path / "job-test-proj-metadata"
+    job_dir.mkdir()
+    output_file = job_dir / "out"
+    metadata_file = job_dir / "metadata.json"
+
+    first_asset_source = get_test_data_file(
         "binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif"
     )
-    first_asset = str(first_asset_path)
-    # For the second file: use a copy of the first file  (in the temp dir) so we know
-    # that GDAL will find exactly the same metadata under a different asset path.
-    second_asset_path = tmp_path / first_asset_path.name
-    second_asset = str(second_asset_path)
-    shutil.copyfile(first_asset_path, second_asset_path)
+    first_asset_name = first_asset_source.name
+    first_asset_dest = job_dir / first_asset_name
+    shutil.copy(first_asset_source, first_asset_dest)
+
+    # For the second file: use a copy of the first file so we know that GDAL
+    # will find exactly the same metadata under a different asset path.
+    second_asset_path = job_dir / f"second_{first_asset_name}"
+    second_asset_name = second_asset_path.name
+    shutil.copy(first_asset_source, second_asset_path)
+
     asset_meta = {
-        first_asset: {
-            "href": first_asset,
+        first_asset_name: {
+            "href": first_asset_name,
             "roles": "data",
         },
-        # use same file twice to simulate the same CRS and bbox
-        second_asset: {
-            "href": second_asset,
+        # Use same file twice to simulate the same CRS and bbox.
+        second_asset_name: {
+            "href": second_asset_name,
             "roles": "data",
         },
     }
@@ -505,8 +514,8 @@ def test_run_job_get_projection_extension_metadata_all_assets_same_epsg_and_bbox
         job_specification={
             "process_graph": {"nop": {"process_id": "discard_result", "result": True}}
         },
-        output_file=tmp_path / "out",
-        metadata_file=tmp_path / "metadata.json",
+        output_file=output_file,
+        metadata_file=metadata_file,
         api_version="1.0.0",
         job_dir="./",
         dependencies={},
@@ -514,16 +523,16 @@ def test_run_job_get_projection_extension_metadata_all_assets_same_epsg_and_bbox
     )
 
     cube_mock.write_assets.assert_called_once()
-    metadata_result = read_json(tmp_path / "metadata.json")
+    metadata_result = read_json(metadata_file)
     assert metadata_result == {
         "assets": {
-            first_asset: {
-                "href": first_asset,
+            first_asset_name: {
+                "href": first_asset_name,
                 "roles": "data",
                 # Projection extension metadata should not be here, but higher up.
             },
-            second_asset: {
-                "href": second_asset,
+            second_asset_name: {
+                "href": second_asset_name,
                 "roles": "data",
                 # Idem: projection extension metadata should not be here, but higher up.
             },
@@ -602,31 +611,38 @@ def test_run_job_get_projection_extension_metadata_assets_with_different_epsg(
     """
     cube_mock = MagicMock()
 
-    first_asset_path = get_test_data_file(
+    job_dir = tmp_path / "job-test-proj-metadata"
+    job_dir.mkdir()
+    output_file = job_dir / "out"
+    metadata_file = job_dir / "metadata.json"
+
+    first_asset_source = get_test_data_file(
         "binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif"
     )
-    first_asset = str(first_asset_path)
+    first_asset_name = first_asset_source.name
+    first_asset_dest = job_dir / first_asset_name
+    shutil.copy(first_asset_source, first_asset_dest)
 
-    # For the second file: use a copy of the first file  (in the temp dir) so we know
-    # that GDAL will find exactly the same metadata under a different asset path.
-    second_asset_path = tmp_path / first_asset_path.name
-    second_asset = str(second_asset_path)
+    # For the second file: use a copy of the first file so we know that GDAL
+    # will find exactly the same metadata under a different asset path.
+    second_asset_path = job_dir / f"second_{first_asset_name}"
+    second_asset_name = second_asset_path.name
     reproject_raster_file(
-        source_path=first_asset,
-        destination_path=second_asset,
+        source_path=str(first_asset_source),
+        destination_path=str(second_asset_path),
         dest_crs="EPSG:3812",
         width=720,
         height=1188,
     )
 
     asset_meta = {
-        first_asset: {
-            "href": first_asset,
+        first_asset_name: {
+            "href": first_asset_name,
             "roles": "data",
         },
         # use same file twice to simulate the same CRS and bbox
-        second_asset: {
-            "href": second_asset,
+        second_asset_name: {
+            "href": second_asset_name,
             "roles": "data",
         },
     }
@@ -652,8 +668,8 @@ def test_run_job_get_projection_extension_metadata_assets_with_different_epsg(
         job_specification={
             "process_graph": {"nop": {"process_id": "discard_result", "result": True}}
         },
-        output_file=tmp_path / "out",
-        metadata_file=tmp_path / "metadata.json",
+        output_file=output_file,
+        metadata_file=metadata_file,
         api_version="1.0.0",
         job_dir="./",
         dependencies={},
@@ -661,18 +677,18 @@ def test_run_job_get_projection_extension_metadata_assets_with_different_epsg(
     )
 
     cube_mock.write_assets.assert_called_once()
-    metadata_result = read_json(tmp_path / "metadata.json")
+    metadata_result = read_json(metadata_file)
     assert metadata_result == {
         "assets": {
-            first_asset: {
-                "href": first_asset,
+            first_asset_name: {
+                "href": first_asset_name,
                 "roles": "data",
                 "proj:bbox": [5.3997917, 50.0001389, 5.6997917, 50.3301389],
                 "proj:epsg": 4326,
                 "proj:shape": [720, 1188],
             },
-            second_asset: {
-                "href": second_asset,
+            second_asset_name: {
+                "href": second_asset_name,
                 "roles": "data",
                 "proj:bbox": [723413.644, 577049.010, 745443.909, 614102.693],
                 "proj:epsg": 3812,


### PR DESCRIPTION
### Follow up PR to fix bug

The STAC projection metadata was not present, most likely because the asset path was relative to the job directory, and the job directory can be different from the current working directory at run time, therefore the file was not found via its relative path.

Reported here:
https://github.com/Open-EO/openeo-geotrellis-extensions/issues/72#issuecomment-1491745761

>Doesn't seem to work yet in all cases after deployment, it could be that a relative asset path is tried, but should first be >resolved to absolute directory.
> 
>j-a0d82f65376e4d468c7335438334f5b0
> 
> Could not get projection extension metadata, gdal.Info failed for following asset:
> croptype_openEO_platform_E324N170_2020-01-01Z.tif. Either file does not exist or else it is probably not a raster.
> Exception from GDAL: croptype_openEO_platform_E324N170_2020-01-01Z.tif: No such file or directory


### Solution 

Solution is to resolve the relative asset path to an absolute path using the job directory as the base directory, then passing that to `read_projection_extension_metadata`.

Unit tests that cover this functionality have been adapted so they now use relative asset paths. This was basically missing test coverage.

Note that these tests no longer cover asset names that are absolute paths, because there is little use for that. 
- The paths will likely always be relative. 
- Also testing with the relative path basically implies that using the absolute path would also work.

## Related PR

PR on the integration tests, that adds coverage for STAC projection metadata:
 
https://github.com/Open-EO/openeo-geopyspark-integrationtests/pull/5


Because PR https://github.com/Open-EO/openeo-geopyspark-driver/pull/389 fixes the issue that the other PR on the integration tests is checking for, it would be best to first merge the PR with the fix.

Otherwise the integration tests will certainly fail and that may block the deployment of other (unrelated) PRs of the GeoPySpark driver after they are merged.