### PR TITLE
Add more logging for STAC projection metatada

### DIFF
--- a/openeogeotrellis/deploy/batch_job.py
+++ b/openeogeotrellis/deploy/batch_job.py
@@ -276,7 +276,10 @@ def _export_result_metadata(tracer: DryRunDataTracer, result: SaveResult, output
                 # Won't assume the asset path is relative to the current working directory.
                 # It should be relative to the job directory.
                 abs_asset_path = get_abs_path_of_asset(asset_path, output_file.parent)
-                logger.info(f"{asset_path=} maps to absolute path: {abs_asset_path=}")
+                logger.info(
+                    f"{asset_path=} maps to absolute path: {abs_asset_path=} , "
+                    + f"{abs_asset_path.exists()=}"
+                )
 
                 asset_proj_metadata = read_projection_extension_metadata(abs_asset_path)
                 # If gdal could not extract the projection metadata from the file
@@ -771,6 +774,7 @@ def run_job(
     job_dir = Path(job_dir)
 
     logger.info(f"Job spec: {json.dumps(job_specification,indent=1)}")
+    logger.info(f"{job_dir=}, {job_dir.resolve()=}, {output_file=}, {metadata_file=}")
     process_graph = job_specification['process_graph']
     job_options = job_specification.get("job_options", {})
 

--- a/tests/deploy/test_batch_job.py
+++ b/tests/deploy/test_batch_job.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import tempfile
 from mock import MagicMock
 from pathlib import Path
 from unittest import mock
@@ -738,118 +739,123 @@ def test_run_job_get_projection_extension_metadata_assets_with_different_epsg(
 
 
 @mock.patch("openeo_driver.ProcessGraphDeserializer.evaluate")
-def test_run_job_get_projection_extension_metadata_job_dir_is_relative_path(
-    evaluate, tmp_path, monkeypatch
-):
+def test_run_job_get_projection_extension_metadata_job_dir_is_relative_path(evaluate):
     cube_mock = MagicMock()
+    # job dir should be a relative path,
+    # We still want the test data to be cleaned up though, so we need to use
+    # tempfile instead of pytest's tmp_path.
+    with tempfile.TemporaryDirectory(
+        dir=".", suffix="job-test-proj-metadata"
+    ) as job_dir:
+        job_dir = Path(job_dir)
+        assert not job_dir.is_absolute()
 
-    job_dir = Path("./tmp/job-test-proj-metadata")
-    if not job_dir.exists():
-        job_dir.mkdir(parents=True)
-    # Also user relative: run_job should interprete output_file and
-    # metadata_file as relative to the job dir in this case.
-    output_file = "out"
-    metadata_file = "metadata.json"
+        # Note that batch_job's main() interprets its output_file and metadata_file
+        # arguments as relative to job_dir, but run_job does not!
+        output_file = job_dir / "out"
+        metadata_file = job_dir / "metadata.json"
 
-    first_asset_source = get_test_data_file(
-        "binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif"
-    )
-    first_asset_name = first_asset_source.name
-    first_asset_dest = job_dir / first_asset_name
-    shutil.copy(first_asset_source, first_asset_dest)
+        first_asset_source = get_test_data_file(
+            "binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif"
+        )
+        first_asset_name = first_asset_source.name
+        first_asset_dest = job_dir / first_asset_name
+        shutil.copy(first_asset_source, first_asset_dest)
 
-    asset_meta = {
-        first_asset_name: {
-            "href": first_asset_name,  # A path relative to the job dir must work.
-            "roles": "data",
-        },
-        # The second file does not exist on the filesystem.
-        # This triggers that the projection extension metadata is put on the
-        # bands, for the remaining assets (Here there is only 1 other asset off course).
-        "openEO01-05.tif": {"href": "openEO01-05.tif", "roles": "data"},
-    }
-    cube_mock.write_assets.return_value = asset_meta
-    evaluate.return_value = ImageCollectionResult(
-        cube=cube_mock, format="GTiff", options={"multidate": True}
-    )
-    t = _get_tracker()
-    t.setGlobalTracking(True)
-    t.clearGlobalTracker()
-    # tracker reset, so get it again
-    t = _get_tracker()
-    PU_COUNTER = "Sentinelhub_Processing_Units"
-    t.registerDoubleCounter(PU_COUNTER)
-    t.add(PU_COUNTER, 1.4)
-    t.addInputProducts("collectionName", ["http://myproduct1", "http://myproduct2"])
-    t.addInputProducts("collectionName", ["http://myproduct3"])
-    t.addInputProducts("other_collectionName", ["http://myproduct4"])
-    t.add(PU_COUNTER, 0.4)
-
-    run_job(
-        job_specification={
-            "process_graph": {"nop": {"process_id": "discard_result", "result": True}}
-        },
-        output_file=output_file,
-        metadata_file=metadata_file,
-        api_version="1.0.0",
-        job_dir=job_dir,
-        dependencies={},
-        user_id="jenkins",
-    )
-
-    cube_mock.write_assets.assert_called_once()
-    metadata_result = read_json(metadata_file)
-    assert metadata_result == {
-        "assets": {
+        asset_meta = {
             first_asset_name: {
-                "href": first_asset_name,
+                "href": first_asset_name,  # A path relative to the job dir must work.
                 "roles": "data",
-                "proj:bbox": [5.3997917, 50.0001389, 5.6997917, 50.3301389],
-                "proj:epsg": 4326,
-                "proj:shape": [720, 1188],
             },
+            # The second file does not exist on the filesystem.
+            # This triggers that the projection extension metadata is put on the
+            # bands, for the remaining assets (Here there is only 1 other asset off course).
             "openEO01-05.tif": {"href": "openEO01-05.tif", "roles": "data"},
-        },
-        "bbox": None,
-        "epsg": None,
-        "end_datetime": None,
-        "geometry": None,
-        "area": None,
-        "unique_process_ids": ["discard_result"],
-        "instruments": [],
-        "links": [
-            {
-                "href": "http://myproduct4",
-                "rel": "derived_from",
-                "title": "Derived from http://myproduct4",
+        }
+        cube_mock.write_assets.return_value = asset_meta
+        evaluate.return_value = ImageCollectionResult(
+            cube=cube_mock, format="GTiff", options={"multidate": True}
+        )
+        t = _get_tracker()
+        t.setGlobalTracking(True)
+        t.clearGlobalTracker()
+        # tracker reset, so get it again
+        t = _get_tracker()
+        PU_COUNTER = "Sentinelhub_Processing_Units"
+        t.registerDoubleCounter(PU_COUNTER)
+        t.add(PU_COUNTER, 1.4)
+        t.addInputProducts("collectionName", ["http://myproduct1", "http://myproduct2"])
+        t.addInputProducts("collectionName", ["http://myproduct3"])
+        t.addInputProducts("other_collectionName", ["http://myproduct4"])
+        t.add(PU_COUNTER, 0.4)
+
+        run_job(
+            job_specification={
+                "process_graph": {
+                    "nop": {"process_id": "discard_result", "result": True}
+                }
             },
-            {
-                "href": "http://myproduct1",
-                "rel": "derived_from",
-                "title": "Derived from http://myproduct1",
+            output_file=output_file,
+            metadata_file=metadata_file,
+            api_version="1.0.0",
+            job_dir=job_dir,
+            dependencies={},
+            user_id="jenkins",
+        )
+
+        cube_mock.write_assets.assert_called_once()
+        metadata_result = read_json(metadata_file)
+        assert metadata_result == {
+            "assets": {
+                first_asset_name: {
+                    "href": first_asset_name,
+                    "roles": "data",
+                    "proj:bbox": [5.3997917, 50.0001389, 5.6997917, 50.3301389],
+                    "proj:epsg": 4326,
+                    "proj:shape": [720, 1188],
+                },
+                "openEO01-05.tif": {"href": "openEO01-05.tif", "roles": "data"},
             },
-            {
-                "href": "http://myproduct2",
-                "rel": "derived_from",
-                "title": "Derived from http://myproduct2",
+            "bbox": None,
+            "epsg": None,
+            "end_datetime": None,
+            "geometry": None,
+            "area": None,
+            "unique_process_ids": ["discard_result"],
+            "instruments": [],
+            "links": [
+                {
+                    "href": "http://myproduct4",
+                    "rel": "derived_from",
+                    "title": "Derived from http://myproduct4",
+                },
+                {
+                    "href": "http://myproduct1",
+                    "rel": "derived_from",
+                    "title": "Derived from http://myproduct1",
+                },
+                {
+                    "href": "http://myproduct2",
+                    "rel": "derived_from",
+                    "title": "Derived from http://myproduct2",
+                },
+                {
+                    "href": "http://myproduct3",
+                    "rel": "derived_from",
+                    "title": "Derived from http://myproduct3",
+                },
+            ],
+            "processing:facility": "VITO - SPARK",
+            "processing:software": "openeo-geotrellis-" + __version__,
+            "start_datetime": None,
+            "usage": {
+                "sentinelhub": {
+                    "unit": "sentinelhub_processing_unit",
+                    "value": 1.7999999999999998,
+                }
             },
-            {
-                "href": "http://myproduct3",
-                "rel": "derived_from",
-                "title": "Derived from http://myproduct3",
-            },
-        ],
-        "processing:facility": "VITO - SPARK",
-        "processing:software": "openeo-geotrellis-" + __version__,
-        "start_datetime": None,
-        "usage": {
-            "sentinelhub": {
-                "unit": "sentinelhub_processing_unit",
-                "value": 1.7999999999999998,
-            }
-        },
-    }
-    t.setGlobalTracking(False)
+        }
+        t.setGlobalTracking(False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Gdalinfo is still receiving a relative path for the asset. Adding more logging to be able to see what is happening.

https://github.com/Open-EO/openeo-geotrellis-extensions/issues/72