### PR TITLE
Download asset from object storage before extracting projection metad…

### DIFF
--- a/openeogeotrellis/deploy/batch_job.py
+++ b/openeogeotrellis/deploy/batch_job.py
@@ -55,7 +55,7 @@ from openeogeotrellis.utils import (
     add_permissions,
     mdc_include,
     to_s3_url,
-    get_s3_file_contents,
+    get_s3_binary_file_contents,
 )
 
 logger = logging.getLogger('openeogeotrellis.deploy.batch_job')
@@ -295,7 +295,7 @@ def _export_result_metadata(tracer: DryRunDataTracer, result: SaveResult, output
                 asset_href = asset_md.get("href", "")
                 if not abs_asset_path.exists() and asset_href.startswith("s3://"):
                     try:
-                        abs_asset_path.write_text(get_s3_file_contents(asset_href))
+                        abs_asset_path.write_bytes(get_s3_binary_file_contents(asset_href))
                     except Exception as exc:
                         logger.error(
                             "Could not download asset from object storage: "

--- a/openeogeotrellis/utils.py
+++ b/openeogeotrellis/utils.py
@@ -348,13 +348,14 @@ def get_s3_file_contents(filename: Union[os.PathLike,str]) -> str:
 
 
 def get_s3_binary_file_contents(s3_url: str) -> bytes:
-    """Get contents of a binary file from the S3 bucket.
-
-    The bucket is set in ConfigParams().s3_bucket_name
-    """
+    """Get contents of a binary file from the S3 bucket."""
     # TODO: move this to openeogeotrellis.integrations.s3?
+
+    # This only supports S3 URLs, does not support filenames with the
+    # S3 bucket set in ConfigParams().
     if not s3_url.startswith("s3://"):
         raise ValueError(f"s3_url must be a URL that starts with 's3://' Value is: {s3_url=}")
+
     bucket, file_name = s3_url[5:].split("/", 1)
     logger.debug("Downloading contents from S3 object storage: {bucket=}, key={file_name}")
 

--- a/openeogeotrellis/utils.py
+++ b/openeogeotrellis/utils.py
@@ -347,6 +347,23 @@ def get_s3_file_contents(filename: Union[os.PathLike,str]) -> str:
     return body.read().decode("utf8")
 
 
+def get_s3_binary_file_contents(s3_url: str) -> bytes:
+    """Get contents of a binary file from the S3 bucket.
+
+    The bucket is set in ConfigParams().s3_bucket_name
+    """
+    # TODO: move this to openeogeotrellis.integrations.s3?
+    if not s3_url.startswith("s3://"):
+        raise ValueError(f"s3_url must be a URL that starts with 's3://' Value is: {s3_url=}")
+    bucket, file_name = s3_url[5:].split("/", 1)
+    logger.debug("Downloading contents from S3 object storage: {bucket=}, key={file_name}")
+
+    s3_instance = s3_client()
+    s3_file_object = s3_instance.get_object(Bucket=bucket, Key=file_name)
+    body = s3_file_object["Body"]
+    return body.read()
+
+
 def to_s3_url(file_or_dir_name: Union[os.PathLike,str], bucketname: str = None) -> str:
     """Get a URL for S3 to the file or directory, in the correct format."""
     # TODO: Does this function belong in the openeo-python-driver?

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -215,7 +215,13 @@ class TestStatsReporter:
 
 
 def test_get_s3_binary_file_contents(mock_s3_bucket):
+    """Upload a file to the mock implementation of S3 and check that our wrapper
+    function can download it correctly, meaning:
+    - it processes the S3 URL correctly
+    - it downloads the file as binary, so the result should be identical byte for byte.
+    """
     output_file = "foo/bar.tif"
+    # mock_s3_bucket sets the ConfigParams().s3_bucket_name to a fake test bucket.
     out_file_s3_url = f"s3://{ConfigParams().s3_bucket_name}/{output_file}"
     mock_s3_bucket.put_object(Key=output_file, Body=TIFF_DUMMY_DATA)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from openeo_driver.testing import TIFF_DUMMY_DATA
+from openeogeotrellis.configparams import ConfigParams
 from openeogeotrellis.utils import (
     dict_merge_recursive,
     describe_path,
@@ -15,6 +17,7 @@ from openeogeotrellis.utils import (
     UtcNowClock,
     single_value,
     StatsReporter,
+    get_s3_binary_file_contents,
 )
 
 
@@ -209,3 +212,13 @@ class TestStatsReporter:
                 stats["coconut"] = 8
 
         assert caplog.messages == ['stats: {"apple": 1, "banana": 12}']
+
+
+def test_get_s3_binary_file_contents(mock_s3_bucket):
+    output_file = "foo/bar.tif"
+    out_file_s3_url = f"s3://{ConfigParams().s3_bucket_name}/{output_file}"
+    mock_s3_bucket.put_object(Key=output_file, Body=TIFF_DUMMY_DATA)
+
+    bytes_retrieved = get_s3_binary_file_contents(out_file_s3_url)
+
+    assert TIFF_DUMMY_DATA == bytes_retrieved

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -327,44 +327,6 @@ class TestCollections:
                 assert [b[f] for b in resp['summaries']['eo:bands'] if f in b] == [b[f] for b in eo_bands if f in b]
 
 
-TEST_AWS_REGION_NAME = 'eu-central-1'
-
-@pytest.fixture(scope='function')
-def aws_credentials(monkeypatch):
-    """Mocked AWS Credentials for moto."""
-    monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'testing')
-    monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'testing')
-    monkeypatch.setenv('AWS_SECURITY_TOKEN', 'testing')
-    monkeypatch.setenv('AWS_SESSION_TOKEN', 'testing')
-    monkeypatch.setenv('AWS_DEFAULT_REGION', TEST_AWS_REGION_NAME)
-    monkeypatch.setenv('AWS_REGION', TEST_AWS_REGION_NAME)
-
-
-@pytest.fixture(scope='function')
-def mock_s3_resource(aws_credentials):
-    with mock_s3():
-        yield boto3.resource("s3", region_name=TEST_AWS_REGION_NAME)
-
-
-@pytest.fixture(scope='function')
-def mock_s3_client(aws_credentials):
-    with mock_s3():
-        yield boto3.s3_client("s3", region_name=TEST_AWS_REGION_NAME)
-
-
-@pytest.fixture(scope='function')
-def mock_s3_bucket(mock_s3_resource, monkeypatch):
-    # TODO: bucket_name: there could be a mismatch with ConfigParams().s3_bucket_name if any ConfigParams instances were created earlier in the test setup.
-    bucket_name = "openeo-fake-bucketname"
-    monkeypatch.setenv("SWIFT_BUCKET", bucket_name)
-    from openeogeotrellis.configparams import ConfigParams
-    assert ConfigParams().s3_bucket_name == bucket_name
-
-    bucket = mock_s3_resource.Bucket(bucket_name)
-    bucket.create(CreateBucketConfiguration={'LocationConstraint': TEST_AWS_REGION_NAME})
-    yield bucket
-
-
 def create_files_on_s3(s3_bucket, file_names, file_contents):
     for fname, contents in zip(file_names, file_contents):
         s3_bucket.put_object(Key=fname, Body=contents)


### PR DESCRIPTION
## Download asset from object storage before extracting projection metadata with gdalinfo

Fix for issue #403

This PR contains only the fix. Test coverage will be added in a follow up PR.
We want to merge this quickly to alleviate the problem. Therefore the change is kept small and safe.