### PR TITLE
Open-EO/openeo-geopyspark-driver#429 Move error test fom Python to Scala.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,8 +104,7 @@ def _setup_local_spark(out: TerminalReporter, verbosity=0):
     conf.set(key="spark.driver.memory", value="2G")
     conf.set(key="spark.executor.memory", value="2G")
     OPENEO_LOCAL_DEBUGGING = smart_bool(os.environ.get("OPENEO_LOCAL_DEBUGGING", "false"))
-    if OPENEO_LOCAL_DEBUGGING:
-        conf.set('spark.ui.enabled', True)
+    conf.set('spark.ui.enabled', OPENEO_LOCAL_DEBUGGING)
 
     jars = []
     for jar_dir in additional_jar_dirs:

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -131,39 +131,3 @@ def test_circuit_breaker_raises_openeoapiexception(mock_search):
         + "and report this error if it persists. (ref: no-request)"
     )
     assert raise_context.value.message == expected_message
-
-
-def test_spark_log(caplog):
-    from pyspark import SparkContext
-    from openeogeotrellis.utils import get_jvm, mdc_include
-    OPENEO_BATCH_JOB_ID = os.environ.get("OPENEO_BATCH_JOB_ID", "unknown-job")
-
-    def _setup_java_logging(sc: SparkContext, user_id: str):
-        jvm = get_jvm()
-        mdc_include(sc, jvm, jvm.org.openeo.logging.JsonLayout.UserId(), user_id)
-        mdc_include(sc, jvm, jvm.org.openeo.logging.JsonLayout.JobId(), OPENEO_BATCH_JOB_ID)
-
-    user_id = "testUserId"
-    sc = SparkContext.getOrCreate()
-
-    _setup_java_logging(sc, user_id)
-    jvm = get_jvm()
-    logger = jvm.org.slf4j.LoggerFactory.getLogger("be.example")
-    _setup_java_logging(sc, user_id)
-
-    logger.warn("Test warning message")
-
-    def throw_function(x):
-        raise AssertionError("Boom!")
-        return x
-
-    try:
-        count = sc.parallelize([1, 2, 3], numSlices=2).map(throw_function).sum()
-        print(count)
-    except Exception as e:
-        print(type(e))
-
-    with open('openeo.log', 'r') as file:
-        data = file.read()
-        assert "TaskSetManager" in data
-        assert "job_id" in data


### PR DESCRIPTION
To be merged together with this one: https://github.com/Open-EO/openeo-geotrellis-extensions/pull/165