### PR TITLE
Open-EO/openeo-geotrellis-extensions#152 set noResampleOnRead for TERRASCOPE_S2_TOC_V2

### DIFF
--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -291,6 +291,8 @@ class GeoPySparkLayerCatalog(CollectionCatalog):
 
 
         def file_s2_pyramid():
+            if collection_id == "TERRASCOPE_S2_TOC_V2":
+                datacubeParams.setNoResampleOnRead(True)
             def pyramid_factory(
                 opensearch_endpoint,
                 opensearch_collection_id,


### PR DESCRIPTION
@jdries Is it okay to explicitly set noResampleOnRead for TERRASCOPE_S2_TOC_V2? When merged, this will enable ResampledTiles for TERRASCOPE_S2_TOC_V2 where all tiles will be visible as 10m even though their source raster data is in for example 20m or 60m resolution.