### PR TITLE
Skipping Terrascope less fast. Use jvm opensearch.

### DIFF
--- a/openeogeotrellis/collections/s1backscatter_orfeo.py
+++ b/openeogeotrellis/collections/s1backscatter_orfeo.py
@@ -240,7 +240,7 @@ class S1BackscatterOrfeo:
             # TODO Get tiff path from manifest instead of assuming this `measurement` file structure?
             band_regex = re.compile(r"^s1[ab]-iw-grd-([hv]{2})-", flags=re.IGNORECASE)
             band_tiffs = {}
-            for tiff in creo_path.glob("measurement/*.tiff"):
+            for tiff in creo_path.glob("*/measurement/*.tiff"):
                 match = band_regex.match(tiff.name)
                 if match:
                     band_tiffs[match.group(1).lower()] = tiff

--- a/openeogeotrellis/collections/s1backscatter_orfeo.py
+++ b/openeogeotrellis/collections/s1backscatter_orfeo.py
@@ -240,7 +240,7 @@ class S1BackscatterOrfeo:
             # TODO Get tiff path from manifest instead of assuming this `measurement` file structure?
             band_regex = re.compile(r"^s1[ab]-iw-grd-([hv]{2})-", flags=re.IGNORECASE)
             band_tiffs = {}
-            for tiff in creo_path.glob("*/measurement/*.tiff"):
+            for tiff in creo_path.glob("measurement/*.tiff"):
                 match = band_regex.match(tiff.name)
                 if match:
                     band_tiffs[match.group(1).lower()] = tiff

--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -984,10 +984,6 @@ def query_jvm_opensearch_client(open_search_client, collection_id, _query_kwargs
     attribute_values_dict = {}
     if "cldPrcnt" in _query_kwargs:
         attribute_values_dict["eo:cloud_cover"] = _query_kwargs["cldPrcnt"]
-    if "eo:cloud_cover" not in attribute_values_dict:
-        # Terrascope only has <95% clouded tiles, so use as default
-        # So we will not get missing warnings for totally clouded tiles.
-        attribute_values_dict["eo:cloud_cover"] = 95
     attributeV_values = jvm.PythonUtils.toScalaMap(attribute_values_dict)
     products = open_search_client.getProducts(
         collection_id, dateRange,

--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -1020,7 +1020,8 @@ def check_missing_products(
         elif method == "terrascope":
             jvm = get_jvm()
 
-            def query_trough_java(open_search_client, collection_id, _query_kwargs, cloud_percent=100):
+            def query_trough_java(open_search_client, collection_id, _query_kwargs, processing_level="",
+                                  cloud_percent=100):
                 fromDate = jvm.java.time.ZonedDateTime.parse(str(_query_kwargs["start_date"]).replace(" ", "T") + "Z")
                 toDate = jvm.java.time.ZonedDateTime.parse(str(_query_kwargs["end_date"]).replace(" ", "T") + "Z")
                 dateRange = jvm.scala.Some(jvm.scala.Tuple2(fromDate, toDate))
@@ -1032,7 +1033,7 @@ def check_missing_products(
                 attributeValues = jvm.PythonUtils.toScalaMap(attributeValuesDict)
                 products = open_search_client.getProducts(
                     collection_id, dateRange,
-                    bbox, attributeValues, "", ""
+                    bbox, attributeValues, "", processing_level
                 )
                 return {
                     (
@@ -1046,6 +1047,7 @@ def check_missing_products(
                 open_search_client=jvm.org.openeo.opensearch.backends.CreodiasClient.apply(),
                 collection_id=check_data["creo_catalog"]["mission"],
                 _query_kwargs=query_kwargs,
+                processing_level=check_data["creo_catalog"]["level"],
                 cloud_percent=95,
             )
 

--- a/tests/data_collections/test_s1backscatter_orfeo.py
+++ b/tests/data_collections/test_s1backscatter_orfeo.py
@@ -358,15 +358,7 @@ class TestOrfeoPipeline:
         """
         # Provide test Sentinel-1 and DEM data.
         symlinks = {
-            "./data/binary/s1backscatter_orfeo/Sentinel-1/zeebrugge_2020_06_06.SAFE": [
-                "/eodata/Sentinel-1/SAR/GRD/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060615_20200606T060640_021909_029944_4C69.SAFE",
-                "/eodata/Sentinel-1/SAR/GRD/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060612_20200606T060637_021909_029944_0FCC.SAFE",
-            ],
-            "./data/binary/s1backscatter_orfeo/Sentinel-1/laroche_2020_07_29.SAFE": [
-                "/eodata/Sentinel-1/SAR/GRD/2020/07/29/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_E12B.SAFE",
-                "/eodata/Sentinel-1/SAR/GRD/2020/07/29/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_E424.SAFE",
-            ],
-            "./data/binary/s1backscatter_orfeo/Sentinel-1/laroche_2020_07_29_SAR.SAFE": [
+            "./data/binary/s1backscatter_orfeo/Sentinel-1/laroche_2020_07_29_COG.SAFE": [
                 "/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2020/07/29/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_B0A1_COG.SAFE/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_B0A1_COG.SAFE/",
             ],
             "./data/binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif": [
@@ -375,7 +367,7 @@ class TestOrfeoPipeline:
             "./data/binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N51_00_E003_00_DEM/Copernicus_DSM_COG_10_N51_00_E003_00_DEM.tif": [
                 "/eodata/auxdata/CopDEM_COG/copernicus-dem-30m/Copernicus_DSM_COG_10_N51_00_E003_00_DEM/Copernicus_DSM_COG_10_N51_00_E003_00_DEM.tif"
             ],
-            "./data/binary/s1backscatter_orfeo/Sentinel-1/zeebrugge_2020_06_06_SAR.SAFE": [
+            "./data/binary/s1backscatter_orfeo/Sentinel-1/zeebrugge_2020_06_06_COG.SAFE": [
                 "/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060615_20200606T060640_021909_029944_094C_COG.SAFE/S1B_IW_GRDH_1SDV_20200606T060615_20200606T060640_021909_029944_094C_COG.SAFE",
                 "/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060612_20200606T060637_021909_029944_1FC2_COG.SAFE/S1B_IW_GRDH_1SDV_20200606T060612_20200606T060637_021909_029944_1FC2_COG.SAFE",
             ],

--- a/tests/data_collections/test_s1backscatter_orfeo.py
+++ b/tests/data_collections/test_s1backscatter_orfeo.py
@@ -358,18 +358,19 @@ class TestOrfeoPipeline:
         """
         # Provide test Sentinel-1 and DEM data.
         symlinks = {
-            "./data/binary/s1backscatter_orfeo/Sentinel-1/laroche_2020_07_29_COG.SAFE": [
-                "/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2020/07/29/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_B0A1_COG.SAFE/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_B0A1_COG.SAFE/",
+            "./data/binary/s1backscatter_orfeo/Sentinel-1/zeebrugge_2020_06_06.SAFE": [
+                "/eodata/Sentinel-1/SAR/GRD/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060615_20200606T060640_021909_029944_4C69.SAFE",
+                "/eodata/Sentinel-1/SAR/GRD/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060612_20200606T060637_021909_029944_0FCC.SAFE",
+            ],
+            "./data/binary/s1backscatter_orfeo/Sentinel-1/laroche_2020_07_29.SAFE": [
+                "/eodata/Sentinel-1/SAR/GRD/2020/07/29/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_E12B.SAFE",
+                "/eodata/Sentinel-1/SAR/GRD/2020/07/29/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_E424.SAFE",
             ],
             "./data/binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif": [
                 "/eodata/auxdata/CopDEM_COG/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif"
             ],
             "./data/binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N51_00_E003_00_DEM/Copernicus_DSM_COG_10_N51_00_E003_00_DEM.tif": [
                 "/eodata/auxdata/CopDEM_COG/copernicus-dem-30m/Copernicus_DSM_COG_10_N51_00_E003_00_DEM/Copernicus_DSM_COG_10_N51_00_E003_00_DEM.tif"
-            ],
-            "./data/binary/s1backscatter_orfeo/Sentinel-1/zeebrugge_2020_06_06_COG.SAFE": [
-                "/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060615_20200606T060640_021909_029944_094C_COG.SAFE/S1B_IW_GRDH_1SDV_20200606T060615_20200606T060640_021909_029944_094C_COG.SAFE",
-                "/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060612_20200606T060637_021909_029944_1FC2_COG.SAFE/S1B_IW_GRDH_1SDV_20200606T060612_20200606T060637_021909_029944_1FC2_COG.SAFE",
             ],
         }
         for dest_path, source_paths in symlinks.items():

--- a/tests/data_collections/test_s1backscatter_orfeo.py
+++ b/tests/data_collections/test_s1backscatter_orfeo.py
@@ -372,6 +372,10 @@ class TestOrfeoPipeline:
             "./data/binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N51_00_E003_00_DEM/Copernicus_DSM_COG_10_N51_00_E003_00_DEM.tif": [
                 "/eodata/auxdata/CopDEM_COG/copernicus-dem-30m/Copernicus_DSM_COG_10_N51_00_E003_00_DEM/Copernicus_DSM_COG_10_N51_00_E003_00_DEM.tif"
             ],
+            "./data/binary/s1backscatter_orfeo/Sentinel-1/zeebrugge_2020_06_06_SAR.SAFE": [
+                "/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060615_20200606T060640_021909_029944_094C_COG.SAFE/S1B_IW_GRDH_1SDV_20200606T060615_20200606T060640_021909_029944_094C_COG.SAFE",
+                "/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2020/06/06/S1B_IW_GRDH_1SDV_20200606T060612_20200606T060637_021909_029944_1FC2_COG.SAFE/S1B_IW_GRDH_1SDV_20200606T060612_20200606T060637_021909_029944_1FC2_COG.SAFE",
+            ],
         }
         for dest_path, source_paths in symlinks.items():
             dest_path = Path(__file__).parent.parent / dest_path

--- a/tests/data_collections/test_s1backscatter_orfeo.py
+++ b/tests/data_collections/test_s1backscatter_orfeo.py
@@ -366,6 +366,9 @@ class TestOrfeoPipeline:
                 "/eodata/Sentinel-1/SAR/GRD/2020/07/29/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_E12B.SAFE",
                 "/eodata/Sentinel-1/SAR/GRD/2020/07/29/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_E424.SAFE",
             ],
+            "./data/binary/s1backscatter_orfeo/Sentinel-1/laroche_2020_07_29_SAR.SAFE": [
+                "/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2020/07/29/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_B0A1_COG.SAFE/S1B_IW_GRDH_1SDV_20200729T172345_20200729T172410_022689_02B10A_B0A1_COG.SAFE/",
+            ],
             "./data/binary/s1backscatter_orfeo/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif": [
                 "/eodata/auxdata/CopDEM_COG/copernicus-dem-30m/Copernicus_DSM_COG_10_N50_00_E005_00_DEM/Copernicus_DSM_COG_10_N50_00_E005_00_DEM.tif"
             ],

--- a/tests/test_api_result.py
+++ b/tests/test_api_result.py
@@ -10,6 +10,7 @@ from typing import List, Union, Sequence
 import mock
 import numpy as np
 import pytest
+from mock import MagicMock
 import rasterio
 import xarray
 from numpy.testing import assert_equal
@@ -1922,7 +1923,26 @@ def test_extra_validation_creo(api100, requests_mock):
     ]}
 
 
-def test_extra_validation_terrascope(api100, requests_mock):
+@pytest.fixture
+def jvm_mock():
+    with mock.patch('openeogeotrellis.layercatalog.get_jvm') as get_jvm:
+        jvm_mock = get_jvm.return_value
+        raster_layer = MagicMock()
+        jvm_mock.geopyspark.geotrellis.TemporalTiledRasterLayer.return_value = raster_layer
+        raster_layer.layerMetadata.return_value = """{
+            "crs": "EPSG:4326",
+            "cellType": "uint8",
+            "bounds": {"minKey": {"col":0, "row":0}, "maxKey": {"col": 1, "row": 1}},
+            "extent": {"xmin": 0,"ymin": 0, "xmax": 1,"ymax": 1},
+            "layoutDefinition": {
+                "extent": {"xmin": 0, "ymin": 0,"xmax": 1,"ymax": 1},
+                "tileLayout": {"layoutCols": 1, "layoutRows": 1, "tileCols": 256, "tileRows": 256}
+            }
+        }"""
+        yield jvm_mock
+
+
+def test_extra_validation_terrascope(jvm_mock, api100):
     pg = {"lc": {
         "process_id": "load_collection",
         "arguments": {
@@ -1936,27 +1956,30 @@ def test_extra_validation_terrascope(api100, requests_mock):
         "result": True
     }}
 
-    requests_mock.get(
-        "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?processingLevel=LEVEL1C&startDate=2020-03-01T00%3A00%3A00&cloudCover=%5B0%2C50%5D&page=1&maxRecords=100&sortParam=startDate&sortOrder=ascending&status=all&dataset=ESA-DATASET&completionDate=2020-03-10T23%3A59%3A59.999999&geometry=POLYGON+%28%28-87+68%2C+-86+68%2C+-86+67%2C+-87+67%2C+-87+68%29%29",
-        json=CreoApiMocker.feature_collection(features=[{"tile_id": "16WEA"}, {"tile_id": "16WDA"}]),
-    )
-    requests_mock.get(
-        "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?processingLevel=LEVEL1C&startDate=2020-03-01T00%3A00%3A00&cloudCover=%5B0%2C50%5D&page=2&maxRecords=100&sortParam=startDate&sortOrder=ascending&status=all&dataset=ESA-DATASET&completionDate=2020-03-10T23%3A59%3A59.999999&geometry=POLYGON+%28%28-87+68%2C+-86+68%2C+-86+67%2C+-87+67%2C+-87+68%29%29",
-        json=CreoApiMocker.feature_collection(features=[]),
-    )
-    requests_mock.get(
-        "https://services.terrascope.be/catalogue/products?collection=urn%3Aeop%3AVITO%3ATERRASCOPE_S2_TOC_V2&bbox=-87%2C67%2C-86%2C68&sortKeys=title&startIndex=1&start=2020-03-01T00%3A00%3A00&end=2020-03-10T23%3A59%3A59.999999&cloudCover=[0,50]",
-        json=TerrascopeApiMocker.feature_collection(features=[{"tile_id": "16WEA"}]),
-    )
-    requests_mock.get(
-        "https://services.terrascope.be/catalogue/products?collection=urn%3Aeop%3AVITO%3ATERRASCOPE_S2_TOC_V2&bbox=-87%2C67%2C-86%2C68&sortKeys=title&startIndex=2&start=2020-03-01T00%3A00%3A00&end=2020-03-10T23%3A59%3A59.999999&cloudCover=[0,50]",
-        json=TerrascopeApiMocker.feature_collection(features=[]),
-    )
+    simple_layer = jvm_mock.geopyspark.geotrellis.TemporalTiledRasterLayer()
+    jvm_mock.org.openeo.geotrellis.file.PyramidFactory.datacube_seq.return_value = simple_layer
+    jvm_mock.org.openeo.geotrellis.file.PyramidFactory.pyramid_seq.return_value = simple_layer
 
-    response = api100.validation(pg)
-    assert response.json == {'errors': [
-        {'code': 'MissingProduct', 'message': "Tile ('16WDA', '20200301') in collection 'TERRASCOPE_S2_TOC_V2' is not available."}
-    ]}
+    def mock_query_jvm_opensearchclient(open_search_client, collection_id, _query_kwargs, processing_level=""):
+        if "CreodiasClient" in str(open_search_client):
+            mock_collection = [{"tile_id": "16WEA", "date": '20200301'}, {"tile_id": "16WDA", "date": '20200301'}]
+        elif "OscarsClient" in str(open_search_client) or "OpenSearchClient" in str(open_search_client):
+            mock_collection = [{"tile_id": "16WEA", "date": '20200301'}]
+        else:
+            raise Exception("Unknown open_search_client: " + str(open_search_client))
+        return {
+            (p["tile_id"], p["date"])
+            for p in mock_collection
+        }
+
+    with mock.patch("openeogeotrellis.layercatalog.query_jvm_opensearchclient", new=mock_query_jvm_opensearchclient):
+
+        response = api100.validation(pg)
+        expected = {'errors': [
+            {'code': 'MissingProduct',
+             'message': "Tile ('16WDA', '20200301') in collection 'TERRASCOPE_S2_TOC_V2' is not available."}
+        ]}
+        assert list(sorted(map(str, response.json["errors"]))) == list(sorted(map(str, expected["errors"])))
 
 
 @pytest.mark.parametrize(["lc_args", "expected"], [

--- a/tests/test_api_result.py
+++ b/tests/test_api_result.py
@@ -1960,7 +1960,7 @@ def test_extra_validation_terrascope(jvm_mock, api100):
     jvm_mock.org.openeo.geotrellis.file.PyramidFactory.datacube_seq.return_value = simple_layer
     jvm_mock.org.openeo.geotrellis.file.PyramidFactory.pyramid_seq.return_value = simple_layer
 
-    def mock_query_jvm_opensearchclient(open_search_client, collection_id, _query_kwargs, processing_level=""):
+    def mock_query_jvm_opensearch_client(open_search_client, collection_id, _query_kwargs, processing_level=""):
         if "CreodiasClient" in str(open_search_client):
             mock_collection = [{"tile_id": "16WEA", "date": '20200301'}, {"tile_id": "16WDA", "date": '20200301'}]
         elif "OscarsClient" in str(open_search_client) or "OpenSearchClient" in str(open_search_client):
@@ -1972,7 +1972,7 @@ def test_extra_validation_terrascope(jvm_mock, api100):
             for p in mock_collection
         }
 
-    with mock.patch("openeogeotrellis.layercatalog.query_jvm_opensearchclient", new=mock_query_jvm_opensearchclient):
+    with mock.patch("openeogeotrellis.layercatalog.query_jvm_opensearch_client", new=mock_query_jvm_opensearch_client):
 
         response = api100.validation(pg)
         expected = {'errors': [

--- a/tests/test_load_collection.py
+++ b/tests/test_load_collection.py
@@ -354,7 +354,7 @@ def test_load_collection_data_cube_params(jvm_mock, catalog):
     [{"tile_id": "16WEA", "date": "20200302"}, {"tile_id": "16WEA", "date": "20200307"}],
 ])
 def test_load_collection_common_name_by_missing_products(
-        jvm_mock, requests_mock, missing_products, expected_source, creo_features, catalog
+        jvm_mock, missing_products, expected_source, creo_features, catalog
 ):
     load_params = LoadParameters(
         temporal_extent=('2020-03-01', '2020-03-03'),
@@ -362,32 +362,39 @@ def test_load_collection_common_name_by_missing_products(
         bands=['B03'],
     )
 
-    requests_mock.get(
-        "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?processingLevel=LEVEL1C&startDate=2020-03-01T00%3A00%3A00&cloudCover=%5B0%2C100%5D&page=1&maxRecords=100&sortParam=startDate&sortOrder=ascending&status=all&dataset=ESA-DATASET&completionDate=2020-03-03T23%3A59%3A59.999999&geometry=POLYGON+%28%284+52%2C+4.001+52%2C+4.001+51.9999%2C+4+51.9999%2C+4+52%29%29",
-        json=CreoApiMocker.feature_collection(features=creo_features)
-    )
-    requests_mock.get(
-        "https://catalogue.dataspace.copernicus.eu/resto/api/collections/Sentinel2/search.json?processingLevel=LEVEL1C&startDate=2020-03-01T00%3A00%3A00&cloudCover=%5B0%2C100%5D&page=2&maxRecords=100&sortParam=startDate&sortOrder=ascending&status=all&dataset=ESA-DATASET&completionDate=2020-03-03T23%3A59%3A59.999999&geometry=POLYGON+%28%284+52%2C+4.001+52%2C+4.001+51.9999%2C+4+51.9999%2C+4+52%29%29",
-        json=CreoApiMocker.feature_collection(features=[])
-    )
+    simple_layer = jvm_mock.geopyspark.geotrellis.TemporalTiledRasterLayer()
+    jvm_mock.org.openeo.geotrellis.file.PyramidFactory.datacube_seq.return_value = simple_layer
+    jvm_mock.org.openeo.geotrellis.file.PyramidFactory.pyramid_seq.return_value = simple_layer
 
     if missing_products:
         tfs = creo_features[1::2]
     else:
         tfs = creo_features
-    from_index = 1
-    requests_mock.get(
-        f"https://services.terrascope.be/catalogue/products?collection=urn%3Aeop%3AVITO%3ATERRASCOPE_S2_TOC_V2&bbox=4%2C51.9999%2C4.001%2C52&sortKeys=title&startIndex={from_index}&start=2020-03-01T00%3A00%3A00&end=2020-03-03T23%3A59%3A59.999999&cloudCover=%5B0%2C100.0%5D",
-        json=TerrascopeApiMocker.feature_collection(features=tfs),
-    )
-    from_index += len(tfs)
-    requests_mock.get(
-        f"https://services.terrascope.be/catalogue/products?collection=urn%3Aeop%3AVITO%3ATERRASCOPE_S2_TOC_V2&bbox=4%2C51.9999%2C4.001%2C52&sortKeys=title&startIndex={from_index}&start=2020-03-01T00%3A00%3A00&end=2020-03-03T23%3A59%3A59.999999&cloudCover=%5B0%2C100.0%5D",
-        json=TerrascopeApiMocker.feature_collection(features=[]),
-    )
 
-    collection = catalog.load_collection('SENTINEL2_L2A', load_params=load_params, env=EvalEnv())
-    assert collection.metadata.get('id') == expected_source
+    def mock_query_jvm_opensearchclient(open_search_client, collection_id, _query_kwargs, processing_level=""):
+        if "CreodiasClient" in str(open_search_client):
+            mock_collection = creo_features
+        elif "OscarsClient" in str(open_search_client) or "OpenSearchClient" in str(open_search_client):
+            mock_collection = tfs
+        else:
+            raise Exception("Unknown open_search_client: " + str(open_search_client))
+        if len(mock_collection) == 0:
+            return {}
+        elif "date" in mock_collection[0]:
+            return {
+                (p["tile_id"], p["date"])
+                for p in mock_collection
+            }
+        else:
+            return {
+                (p["tile_id"])
+                for p in mock_collection
+            }
+
+    with mock.patch("openeogeotrellis.layercatalog.query_jvm_opensearchclient", new=mock_query_jvm_opensearchclient):
+
+        collection = catalog.load_collection('SENTINEL2_L2A', load_params=load_params, env=EvalEnv())
+        assert collection.metadata.get('id') == expected_source
 
 
 def test_load_disk_collection_pyramid(

--- a/tests/test_load_collection.py
+++ b/tests/test_load_collection.py
@@ -371,7 +371,7 @@ def test_load_collection_common_name_by_missing_products(
     else:
         tfs = creo_features
 
-    def mock_query_jvm_opensearchclient(open_search_client, collection_id, _query_kwargs, processing_level=""):
+    def mock_query_jvm_opensearch_client(open_search_client, collection_id, _query_kwargs, processing_level=""):
         if "CreodiasClient" in str(open_search_client):
             mock_collection = creo_features
         elif "OscarsClient" in str(open_search_client) or "OpenSearchClient" in str(open_search_client):
@@ -391,7 +391,7 @@ def test_load_collection_common_name_by_missing_products(
                 for p in mock_collection
             }
 
-    with mock.patch("openeogeotrellis.layercatalog.query_jvm_opensearchclient", new=mock_query_jvm_opensearchclient):
+    with mock.patch("openeogeotrellis.layercatalog.query_jvm_opensearch_client", new=mock_query_jvm_opensearch_client):
 
         collection = catalog.load_collection('SENTINEL2_L2A', load_params=load_params, env=EvalEnv())
         assert collection.metadata.get('id') == expected_source


### PR DESCRIPTION
Sometimes, the code could switch to Creodias, because there where tiles with 95%+ clouds missing. Now, if we don't explicitly ask for them, we do not consider those tiles.

There is now better logging showing what tiles are missing.

Using the JVM opensearch did not give big differences. Only some test mocks needed to be refactored.