### PR TITLE
Raise clear error for 'SENTINEL_5P_L2' with only 'dataMask'

### DIFF
--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -471,8 +471,15 @@ class GeoPySparkLayerCatalog(CollectionCatalog):
                 return (pyramid_factory.datacube_seq(projected_polygons_native_crs, from_date, to_date,metadata_properties(),collection_id,datacubeParams) if single_level
                         else pyramid_factory.pyramid_seq(extent, srs, from_date, to_date))
             else:
-                if collection_id == 'PLANETSCOPE':
+                shub_band_names = metadata.band_names
 
+                if collection_id == 'SENTINEL_5P_L2':
+                    if shub_band_names == ["dataMask"]:
+                        raise OpenEOApiException(
+                            f"Cant load collection '{collection_id}' with only 'dataMask' band. Add 1 other band to make it work.",
+                            status_code=400)
+
+                if collection_id == 'PLANETSCOPE':
                     if 'byoc_collection_id' in feature_flags:
                         shub_collection_id = dataset_id = feature_flags['byoc_collection_id']
                     else:
@@ -493,7 +500,6 @@ class GeoPySparkLayerCatalog(CollectionCatalog):
                 sample_type = jvm.org.openeo.geotrellissentinelhub.SampleType.withName(
                     layer_source_info.get('sample_type', 'UINT16'))
 
-                shub_band_names = metadata.band_names
 
                 if sar_backscatter_arguments and sar_backscatter_arguments.mask:
                     metadata = metadata.append_band(Band(name='mask', common_name=None, wavelength_um=None))


### PR DESCRIPTION
There was already a check on `collection_id` here, so a test for `SENTINEL_5P_L2` seems acceptable. 
If more checks like this get added in the future something more generic in the layercatalog might be nice.