### PR TITLE
Better FileNotFoundError.

### DIFF
--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -1427,7 +1427,10 @@ class GeoPySparkBackendImplementation(backend.OpenEoBackendImplementation):
             summary = str_truncate(summary, width=width)
         else:
             is_client_error = False  # Give user the benefit of doubt.
-            summary = repr_truncate(error, width=width)
+            if isinstance(error, FileNotFoundError):
+                summary = repr_truncate(str(error), width=width)
+            else:
+                summary = repr_truncate(error, width=width)
 
         return ErrorSummary(error, is_client_error, summary)
 


### PR DESCRIPTION
Changes error from:
`Server error: FileNotFoundError(2, 'No such file or directory')`
to:
`Server error: "[Errno 2] No such file or directory: \'/data/users/Public/emile.sonneveld/ANIN/CROP_MASK/CROP_MASK_STAC/collection.json\'"`

I got it often when referring to a stac catalog on /data