### PR TITLE
workspaces: allow adding a region name in the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ without compromising stable operations.
 ## Unreleased
 
 - Throw error when trying to use unsupported `target_dimension` in `aggregate_spatial` ([#951](https://github.com/Open-EO/openeo-geopyspark-driver/issues/951))
+- Allow specifying region name for an ObjectStorageWorkspace ([#955](https://github.com/Open-EO/openeo-geopyspark-driver/pull/955))
 
 ## 0.51.0
 

--- a/openeogeotrellis/workspace.py
+++ b/openeogeotrellis/workspace.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Union
+from typing import Union, Optional
 from urllib.parse import urlparse
 
 from boto3.s3.transfer import TransferConfig
@@ -18,8 +18,9 @@ class ObjectStorageWorkspace(Workspace):
 
     MULTIPART_THRESHOLD_IN_MB = 50
 
-    def __init__(self, bucket: str):
+    def __init__(self, bucket: str, region: Optional[str] = None):
         self.bucket = bucket
+        self.region = region
 
     def import_file(self, common_path: Union[str, Path], file: Path, merge: str, remove_original: bool = False) -> str:
         merge = os.path.normpath(merge)

--- a/tests/backend_config.py
+++ b/tests/backend_config.py
@@ -30,6 +30,7 @@ workspaces = {
     "tmp_workspace": DiskWorkspace(root_directory=Path("/tmp/workspace")),
     "tmp": DiskWorkspace(root_directory=Path("/tmp")),
     "s3_workspace": ObjectStorageWorkspace(bucket="openeo-fake-bucketname"),
+    "s3_workspace_region": ObjectStorageWorkspace(bucket="openeo-fake-eu-nl", region="eu-nl")
 }
 
 


### PR DESCRIPTION
This does not perform a functional change yet but it does alow specifying a region name as part of the workspace config. That way configs can be updated after this version is life and subsequently a change can be deployed that depends on the region being defined.