### PR TITLE
Avoid gdalinfo on csv and parquet files. Fix fast sleeping in some unittests again. 

### DIFF
--- a/openeogeotrellis/deploy/local.py
+++ b/openeogeotrellis/deploy/local.py
@@ -96,7 +96,7 @@ def setup_local_spark(log_dir: Path = Path.cwd(), verbosity=0):
         -Dtsservice.layersConfigClass=ProdLayersConfiguration -Dtsservice.sparktasktimeout=600 "
     sparkDriverJavaOptions += " -Dgeotrellis.jts.precision.type=fixed -Dgeotrellis.jts.simplification.scale=1e10"
     if OPENEO_LOCAL_DEBUGGING:
-        for port in [5005, 5009]:
+        for port in range(5005, 5009):
             if is_port_free(port):
                 # 'agentlib' to allow attaching a Java debugger to running Spark driver
                 # IntelliJ IDEA: Run -> Edit Configurations -> Remote JVM Debug uses 5005 by default

--- a/openeogeotrellis/integrations/gdal.py
+++ b/openeogeotrellis/integrations/gdal.py
@@ -196,8 +196,9 @@ def _get_metadata_callback(asset_path: str, asset_md: Dict[str, str], job_dir: P
 
     mime_type: str = asset_md.get("type", "")
 
-    # Skip assets that are clearly not images.
-    if asset_path.endswith(".json"):
+    # Skip assets that are clearly not images. TODO: Whitelist instead of blacklist
+    asset_path_extension = Path(asset_path).suffix.lower()
+    if asset_path_extension in [".json", ".csv", ".parquet"]:
         return None
 
     # The asset path should be relative to the job directory.
@@ -494,7 +495,7 @@ def read_gdal_info(asset_uri: str) -> GDALInfo:
             data_gdalinfo = gdal.Info(asset_uri, options=gdal.InfoOptions(format="json", stats=True))
             end = time.time()
             # This can throw a segfault on empty netcdf bands:
-            poorly_log(f"gdal.Info() took {(end - start) * 1000}ms for {asset_uri}", level=logging.DEBUG)  # ~10ms
+            poorly_log(f"gdal.Info() took {int((end - start) * 1000)}ms for {asset_uri}", level=logging.DEBUG)  # ~10ms
         except Exception as exc:
             poorly_log(
                 f"gdalinfo Exception. Statistics won't be added to STAC metadata. '{exc}'.", level=logging.WARNING
@@ -509,7 +510,7 @@ def read_gdal_info(asset_uri: str) -> GDALInfo:
             out = subprocess.check_output(cmd, timeout=60, text=True)
             data_gdalinfo_from_subprocess = parse_json_from_output(out)
             end = time.time()
-            poorly_log(f"gdalinfo took {(end - start) * 1000}ms for {asset_uri}", level=logging.DEBUG)  # ~30ms
+            poorly_log(f"gdalinfo took {int((end - start) * 1000)}ms for {asset_uri}", level=logging.DEBUG)  # ~30ms
             if data_gdalinfo:
                 assert data_gdalinfo_from_subprocess == data_gdalinfo
             else:
@@ -532,7 +533,7 @@ def read_gdal_info(asset_uri: str) -> GDALInfo:
             data_gdalinfo_from_subprocess = parse_json_from_output(out)
             end = time.time()
             poorly_log(
-                f"gdal.Info() subprocess took {(end - start) * 1000}ms for {asset_uri}", level=logging.DEBUG
+                f"gdal.Info() subprocess took {int((end - start) * 1000)}ms for {asset_uri}", level=logging.DEBUG
             )  # ~130ms
             if data_gdalinfo:
                 assert data_gdalinfo_from_subprocess == data_gdalinfo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,7 @@ def _setup_local_spark(out: TerminalReporter, verbosity=0):
     -Dsoftware.amazon.awssdk.http.service.impl=software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService\
     -Dtsservice.layersConfigClass=ProdLayersConfiguration -Dtsservice.sparktasktimeout=600"
     if OPENEO_LOCAL_DEBUGGING:
-        for port in [5005, 5009]:
+        for port in range(5005, 5009):
             if is_port_free(port):
                 # 'agentlib' to allow attaching a Java debugger to running Spark driver
                 # IntelliJ IDEA: Run -> Edit Configurations -> Remote JVM Debug uses 5005 by default

--- a/tests/deploy/test_batch_job.py
+++ b/tests/deploy/test_batch_job.py
@@ -394,11 +394,11 @@ def test_log_lock(tmp_path):
         stop_log_locker()
 
 
-@mock.patch("openeogeotrellis.utils.wait_till_path_available")
+@mock.patch("time.sleep")
 @mock.patch("openeo_driver.ProcessGraphDeserializer.evaluate")
-def test_run_job(evaluate, wait_till_path_available_mock, tmp_path):
+def test_run_job(evaluate, time_sleep_mock, tmp_path):
     cube_mock = MagicMock()
-    wait_till_path_available_mock.return_value = None  # Avoid waiting
+    time_sleep_mock.return_value = None  # Avoid waiting
     asset_meta = {"openEO01-01.tif": {"href": "tmp/openEO01-01.tif", "roles": "data"},"openEO01-05.tif": {"href": "tmp/openEO01-05.tif", "roles": "data"}}
     cube_mock.write_assets.return_value = asset_meta
     evaluate.return_value = ImageCollectionResult(cube=cube_mock, format="GTiff", options={"multidate":True})
@@ -480,11 +480,11 @@ def test_run_job(evaluate, wait_till_path_available_mock, tmp_path):
     t.setGlobalTracking(False)
 
 
-@mock.patch("openeogeotrellis.utils.wait_till_path_available")
+@mock.patch("time.sleep")
 @mock.patch("openeo_driver.ProcessGraphDeserializer.evaluate")
-def test_run_job_get_projection_extension_metadata(evaluate, wait_till_path_available_mock, tmp_path):
+def test_run_job_get_projection_extension_metadata(evaluate, time_sleep_mock, tmp_path):
     cube_mock = MagicMock()
-    wait_till_path_available_mock.return_value = None  # Avoid waiting
+    time_sleep_mock.return_value = None  # Avoid waiting
 
     job_dir = tmp_path / "job-402"
     job_dir.mkdir()
@@ -608,16 +608,14 @@ def test_run_job_get_projection_extension_metadata(evaluate, wait_till_path_avai
     t.setGlobalTracking(False)
 
 
-@mock.patch("openeogeotrellis.utils.wait_till_path_available")
+@mock.patch("time.sleep")
 @mock.patch("openeo_driver.ProcessGraphDeserializer.evaluate")
-def test_run_job_get_projection_extension_metadata_all_assets_same_epsg_and_bbox(
-    evaluate, wait_till_path_available_mock, tmp_path
-):
+def test_run_job_get_projection_extension_metadata_all_assets_same_epsg_and_bbox(evaluate, time_sleep_mock, tmp_path):
     """When there are two raster assets with the same projection metadata, it should put
     those metadata at the level of the item instead of the individual bands.
     """
     cube_mock = MagicMock()
-    wait_till_path_available_mock.return_value = None  # Avoid waiting
+    time_sleep_mock.return_value = None  # Avoid waiting
 
     job_dir = tmp_path / "job-533"
     job_dir.mkdir()
@@ -1052,11 +1050,11 @@ def test_run_job_get_projection_extension_metadata_assets_with_different_epsg(
     t.setGlobalTracking(False)
 
 
-@mock.patch("openeogeotrellis.utils.wait_till_path_available")
+@mock.patch("time.sleep")
 @mock.patch("openeo_driver.ProcessGraphDeserializer.evaluate")
-def test_run_job_get_projection_extension_metadata_job_dir_is_relative_path(evaluate, wait_till_path_available_mock):
+def test_run_job_get_projection_extension_metadata_job_dir_is_relative_path(evaluate, time_sleep_mock):
     cube_mock = MagicMock()
-    wait_till_path_available_mock.return_value = None  # Avoid waiting
+    time_sleep_mock.return_value = None  # Avoid waiting
     # job dir should be a relative path,
     # We still want the test data to be cleaned up though, so we need to use
     # tempfile instead of pytest's tmp_path.


### PR DESCRIPTION
https://github.com/Open-EO/openeo-geopyspark-driver/issues/906