### PR TITLE
Add gdalinfo to assets

### DIFF
--- a/openeogeotrellis/geopysparkdatacube.py
+++ b/openeogeotrellis/geopysparkdatacube.py
@@ -1840,9 +1840,12 @@ class GeopysparkDataCube(DriverDataCube):
         separate_asset_per_band = get_jvm().scala.Option.apply(separate_asset_per_band_tmp)
         bands_metadata = format_options.get("bands_metadata", {})  # band_name -> (tag -> value)
         file_metadata = format_options.get("file_metadata", {})  # tag -> value
+        attach_gdalinfo_assets = format_options.get("attach_gdalinfo_assets", False)
+        if attach_gdalinfo_assets and format != "GTIFF":
+            raise OpenEOApiException(f"attach_gdalinfo_assets is only supported with format GTIFF. Was: {format}")
 
         if separate_asset_per_band.isDefined() and format != "GTIFF":
-            raise OpenEOApiException("separate_asset_per_band is only supported with format GTIFF")
+            raise OpenEOApiException(f"separate_asset_per_band is only supported with format GTIFF. Was: {format}")
 
         filepath_per_band = format_options.get("filepath_per_band", None)
 
@@ -1878,7 +1881,7 @@ class GeopysparkDataCube(DriverDataCube):
 
                 def add_gdalinfo_objects(assets_original):
                     assets_to_add = {}
-                    if format_options.get("attach_gdalinfo_assets", False):
+                    if attach_gdalinfo_assets:
                         for key, value in assets_original.items():
                             href_path = str(value["href"])
                             if os.path.exists(href_path + GDALINFO_SUFFIX):

--- a/openeogeotrellis/geopysparkdatacube.py
+++ b/openeogeotrellis/geopysparkdatacube.py
@@ -1889,6 +1889,7 @@ class GeopysparkDataCube(DriverDataCube):
                                     "href": href_path + GDALINFO_SUFFIX,
                                     "type": "application/json",
                                     "roles": ["metadata"],
+                                    "geometry": value["geometry"],
                                 }
                                 if "bbox" in value:
                                     obj["bbox"] = value["bbox"]

--- a/openeogeotrellis/geopysparkdatacube.py
+++ b/openeogeotrellis/geopysparkdatacube.py
@@ -1889,13 +1889,15 @@ class GeopysparkDataCube(DriverDataCube):
                                     "href": href_path + GDALINFO_SUFFIX,
                                     "type": "application/json",
                                     "roles": ["metadata"],
-                                    "geometry": value["geometry"],
                                 }
                                 if "bbox" in value:
                                     obj["bbox"] = value["bbox"]
+                                if "geometry" in value:
+                                    obj["geometry"] = value["geometry"]
                                 if "datetime" in value:
                                     obj["datetime"] = value["datetime"]
-                                assets_to_add[str(pathlib.Path(href_path + GDALINFO_SUFFIX).name)] = obj
+                                name_key = str(pathlib.Path(href_path + GDALINFO_SUFFIX).relative_to(save_directory))
+                                assets_to_add[name_key] = obj
                     return {**assets_original, **assets_to_add}
 
                 if catalog:

--- a/openeogeotrellis/geopysparkdatacube.py
+++ b/openeogeotrellis/geopysparkdatacube.py
@@ -1878,7 +1878,7 @@ class GeopysparkDataCube(DriverDataCube):
 
                 def add_gdalinfo_objects(assets_original):
                     assets_to_add = {}
-                    if get_backend_config().gdalinfo_from_file:
+                    if format_options.get("attach_gdalinfo_assets", False):
                         for key, value in assets_original.items():
                             href_path = str(value["href"])
                             if os.path.exists(href_path + GDALINFO_SUFFIX):
@@ -2204,7 +2204,7 @@ class GeopysparkDataCube(DriverDataCube):
                 message="Format {f!r} is not supported".format(f=format),
                 code="FormatUnsupported", status_code=400
             )
-        return {str(os.path.basename(filename)):{"href":filename}}
+        return {str(os.path.basename(filename)): {"href": filename, "roles": ["data"]}}
 
     def get_labels(self, geometries, feature_id_property=None):
         # TODO: return more descriptive labels/ids than these autoincrement strings (when possible)?

--- a/openeogeotrellis/integrations/gdal.py
+++ b/openeogeotrellis/integrations/gdal.py
@@ -171,7 +171,7 @@ def _extract_gdal_asset_raster_metadata(
             job_dir,
         )
         for asset_path, asset_md in asset_metadata.items()
-        if "data" in asset_md.get("roles")
+        if "roles" not in asset_md or "data" in asset_md.get("roles")
     ]
     results = exec_parallel_with_fallback(_get_metadata_callback, argument_tuples)
 

--- a/openeogeotrellis/integrations/gdal.py
+++ b/openeogeotrellis/integrations/gdal.py
@@ -18,7 +18,12 @@ from osgeo import gdal
 from openeo_driver.utils import smart_bool
 from openeogeotrellis.config import get_backend_config
 from openeogeotrellis.util.runtime import get_job_id
-from openeogeotrellis.utils import stream_s3_binary_file_contents, _make_set_for_key, parse_json_from_output
+from openeogeotrellis.utils import (
+    stream_s3_binary_file_contents,
+    _make_set_for_key,
+    parse_json_from_output,
+    GDALINFO_SUFFIX,
+)
 
 
 def poorly_log(message: str, level=logging.INFO):
@@ -166,6 +171,7 @@ def _extract_gdal_asset_raster_metadata(
             job_dir,
         )
         for asset_path, asset_md in asset_metadata.items()
+        if "data" in asset_md.get("roles")
     ]
     results = exec_parallel_with_fallback(_get_metadata_callback, argument_tuples)
 
@@ -518,7 +524,6 @@ def read_gdal_info(asset_uri: str) -> GDALInfo:
         )
 
     if backend_config.gdalinfo_from_file:
-        GDALINFO_SUFFIX = "_gdalinfo.json"
         if os.path.exists(asset_uri + GDALINFO_SUFFIX):
             with open(asset_uri + GDALINFO_SUFFIX) as f:
                 data_gdalinfo = json.load(f)

--- a/openeogeotrellis/utils.py
+++ b/openeogeotrellis/utils.py
@@ -54,6 +54,7 @@ from openeogeotrellis.util.runtime import get_job_id
 
 logger = logging.getLogger(__name__)
 
+GDALINFO_SUFFIX = "_gdalinfo.json"
 
 def log_memory(function):
     def memory_logging_wrapper(*args, **kwargs):

--- a/tests/test_batch_result.py
+++ b/tests/test_batch_result.py
@@ -31,7 +31,7 @@ from openeogeotrellis.backend import JOB_METADATA_FILENAME
 from openeogeotrellis.config import get_backend_config
 from openeogeotrellis.deploy.batch_job import run_job
 from openeogeotrellis.deploy.batch_job_metadata import extract_result_metadata
-from openeogeotrellis.utils import s3_client
+from openeogeotrellis.utils import s3_client, GDALINFO_SUFFIX
 from openeogeotrellis.workspace import ObjectStorageWorkspace
 from openeogeotrellis.workspace.custom_stac_io import CustomStacIO
 from .conftest import force_stop_spark_context, _setup_local_spark
@@ -914,7 +914,8 @@ def test_multiple_image_collection_results(tmp_path):
 
 
 @pytest.mark.parametrize("remove_original", [False, True])
-def test_export_workspace(tmp_path, remove_original):
+@pytest.mark.parametrize("attach_gdalinfo_assets", [False, True])
+def test_export_workspace(tmp_path, remove_original, attach_gdalinfo_assets):
     workspace_id = "tmp"
     merge = _random_merge()
 
@@ -932,6 +933,9 @@ def test_export_workspace(tmp_path, remove_original):
             "process_id": "save_result",
             "arguments": {
                 "data": {"from_node": "loadcollection1"},
+                "options": {
+                    "attach_gdalinfo_assets": attach_gdalinfo_assets,
+                },
                 "format": "GTiff"
             },
         },
@@ -979,25 +983,34 @@ def test_export_workspace(tmp_path, remove_original):
             assert "openEO_2021-01-05Z.tif" in job_dir_files
             assert "openEO_2021-01-15Z.tif" in job_dir_files
 
-        assert _paths_relative_to(workspace_dir) == {
+        expected_paths = {
             Path("collection.json"),
             Path("openEO_2021-01-05Z.tif"),
             Path("openEO_2021-01-05Z.tif.json"),
             Path("openEO_2021-01-15Z.tif"),
             Path("openEO_2021-01-15Z.tif.json"),
         }
+        if attach_gdalinfo_assets:
+            expected_paths |= {
+                Path(f"openEO_2021-01-05Z.tif{GDALINFO_SUFFIX}"),
+                Path(f"openEO_2021-01-05Z.tif{GDALINFO_SUFFIX}.json"),
+                Path(f"openEO_2021-01-15Z.tif{GDALINFO_SUFFIX}"),
+                Path(f"openEO_2021-01-15Z.tif{GDALINFO_SUFFIX}.json"),
+            }
+        assert _paths_relative_to(workspace_dir) == expected_paths
 
         stac_collection = pystac.Collection.from_file(str(workspace_dir / "collection.json"))
         stac_collection.validate_all()
 
         item_links = [item_link for item_link in stac_collection.links if item_link.rel == "item"]
-        assert len(item_links) == 2
+        assert len(item_links) == 4 if attach_gdalinfo_assets else 2
         item_link = [item_link for item_link in item_links if "openEO_2021-01-05Z.tif" in item_link.href][0]
 
         assert item_link.media_type == "application/geo+json"
         assert item_link.href == "./openEO_2021-01-05Z.tif.json"
 
         items = list(stac_collection.get_items())
+        items = list(filter(lambda x: "data" in x.assets[x.id].roles, items))
         assert len(items) == 2
 
         item = [item for item in items if item.id == "openEO_2021-01-05Z.tif"][0]

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -299,6 +299,7 @@ class TestDownload:
     @pytest.mark.parametrize("sample_by_feature", [True, False])
     @pytest.mark.parametrize("batch_mode", [True, False])
     @pytest.mark.parametrize("filename_prefix", [None, "prefixTest"])
+    @pytest.mark.parametrize("attach_gdalinfo_assets", [True, False])
     @pytest.mark.parametrize("space_type", ["spacetime", "spatial"])
     @pytest.mark.parametrize("format_arg", ["NETCDF", "GTIFF", "PNG"])
     def test_write_assets_parameterize(self, tmp_path, imagecollection_with_two_bands_and_three_dates,
@@ -310,6 +311,7 @@ class TestDownload:
                                        sample_by_feature,
                                        batch_mode,
                                        filename_prefix,
+                                       attach_gdalinfo_assets,
                                        space_type,
                                        format_arg,
                                        ):
@@ -348,6 +350,7 @@ class TestDownload:
                 "sample_by_feature": sample_by_feature,
                 "batch_mode": batch_mode,
                 "filename_prefix": filename_prefix,  # no effect when outputting single file
+                "attach_gdalinfo_assets": attach_gdalinfo_assets,
 
                 # non parametrized:
                 "geometries": geometries,
@@ -359,8 +362,15 @@ class TestDownload:
         # with open(self.test_write_assets_parameterize_path + test_name + ".json", 'w') as fp:
         #     json.dump(assets, fp, indent=2)
 
+        assets = {k: v for (k, v) in assets.items() if "data" in v["roles"]}
         name, asset = next(iter(assets.items()))
-        print("href of first asset: " + asset['href'])
+        print("href of first asset: " + asset["href"])
+        assets_metadata = {k: v for (k, v) in assets.items() if "data" not in v["roles"]}
+        if format_arg == "GTIFF" and not catalog:
+            if attach_gdalinfo_assets:
+                assert len(assets_metadata) == len(assets)
+            else:
+                assert len(assets_metadata) == 0
 
         if len(assets) == 1:
             assert assets[filename]

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -321,6 +321,9 @@ class TestDownload:
         if batch_mode and sample_by_feature:
             # 'sample_by_feature' is only relevant in 'batch_mode'
             return
+        if attach_gdalinfo_assets and format_arg != "GTIFF":
+            # 'attach_gdalinfo_assets' is only relevant when outputting 'GTIFF'
+            return
 
         if space_type == "spacetime":
             imagecollection = imagecollection_with_two_bands_and_three_dates
@@ -337,7 +340,7 @@ class TestDownload:
             assert False
         filename = "test_download_result" + extension
         geometries = geojson_to_geometry(self.features)
-        assets = imagecollection.write_assets(
+        assets_all = imagecollection.write_assets(
             str(tmp_path / filename),
             format=format_arg,
             format_options={
@@ -362,18 +365,18 @@ class TestDownload:
         # with open(self.test_write_assets_parameterize_path + test_name + ".json", 'w') as fp:
         #     json.dump(assets, fp, indent=2)
 
-        assets = {k: v for (k, v) in assets.items() if "data" in v["roles"]}
-        name, asset = next(iter(assets.items()))
+        assets_data = {k: v for (k, v) in assets_all.items() if "data" in v["roles"]}
+        name, asset = next(iter(assets_data.items()))
         print("href of first asset: " + asset["href"])
-        assets_metadata = {k: v for (k, v) in assets.items() if "data" not in v["roles"]}
+        assets_metadata = {k: v for (k, v) in assets_all.items() if "data" not in v["roles"]}
         if format_arg == "GTIFF" and not catalog:
             if attach_gdalinfo_assets:
-                assert len(assets_metadata) == len(assets)
+                assert len(assets_metadata) == len(assets_data)
             else:
                 assert len(assets_metadata) == 0
 
-        if len(assets) == 1:
-            assert assets[filename]
+        if len(assets_data) == 1:
+            assert assets_data[filename]
             assert filename in asset['href']
         else:
             if filename_prefix:


### PR DESCRIPTION
https://github.com/Open-EO/openeo-geotrellis-extensions/issues/352
Disabled by default, otherwise 44 tests needed to be updated, and probably user code too.
Enable with `options.attach_gdalinfo_assets`