### PR TITLE
Move import that might give confusing error even when not used. Should save 40mb RAM too.

### DIFF
--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -692,6 +692,7 @@ class GeoPySparkLayerCatalog(CollectionCatalog):
                 float(metadata.get("cube:dimensions", "x", "step")),
                 float(metadata.get("cube:dimensions", "y", "step"))
             )
+            # Only import when sentinel3 layer is used to save ~40Mb RAM:
             from openeogeotrellis.collections import sentinel3
 
             pyramid = sentinel3.pyramid(metadata_properties(),

--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -37,7 +37,6 @@ from shapely.geometry.base import BaseGeometry
 from openeogeotrellis import sentinel_hub, datacube_parameters
 from openeogeotrellis.catalogs.creo import CreoCatalogClient
 from openeogeotrellis.collections.s1backscatter_orfeo import get_implementation as get_s1_backscatter_orfeo
-from openeogeotrellis.collections import sentinel3
 from openeogeotrellis.collections.testing import load_test_collection
 from openeogeotrellis.config import get_backend_config
 from openeogeotrellis.configparams import ConfigParams
@@ -693,6 +692,7 @@ class GeoPySparkLayerCatalog(CollectionCatalog):
                 float(metadata.get("cube:dimensions", "x", "step")),
                 float(metadata.get("cube:dimensions", "y", "step"))
             )
+            from openeogeotrellis.collections import sentinel3
 
             pyramid = sentinel3.pyramid(metadata_properties(),
                                         projected_polygons_native_crs, from_date, to_date,

--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -692,7 +692,7 @@ class GeoPySparkLayerCatalog(CollectionCatalog):
                 float(metadata.get("cube:dimensions", "x", "step")),
                 float(metadata.get("cube:dimensions", "y", "step"))
             )
-            # Only import when sentinel3 layer is used to save ~40Mb RAM:
+            # Local import to save some RAM and avoid potential confusing error:
             from openeogeotrellis.collections import sentinel3
 
             pyramid = sentinel3.pyramid(metadata_properties(),


### PR DESCRIPTION
Got this error in a graph with only sentinel2, but with limited python-memory:
```bash
Traceback (most recent call last):
  File "/usr/local/spark/python/lib/pyspark.zip/pyspark/worker.py", line 1227, in main
    func, profiler, deserializer, serializer = read_command(pickleSer, infile)
  File "/usr/local/spark/python/lib/pyspark.zip/pyspark/worker.py", line 90, in read_command
    command = serializer._read_with_length(file)
  File "/usr/local/spark/python/lib/pyspark.zip/pyspark/serializers.py", line 174, in _read_with_length
    return self.loads(obj)
  File "/usr/local/spark/python/lib/pyspark.zip/pyspark/serializers.py", line 472, in loads
    return cloudpickle.loads(obj, encoding=encoding)
  File "/opt/openeo/lib/python3.8/site-packages/openeogeotrellis/collections/sentinel3.py", line 19, in <module>
    from scipy.spatial import cKDTree  # used for tuning the griddata interpolation settings
  File "/opt/openeo/lib/python3.8/site-packages/scipy/spatial/__init__.py", line 104, in <module>
    from ._qhull import *
ImportError: libopenblasp-r0-8b9e111f.3.17.so: failed to map segment from shared object
```