### PR TITLE
Use drop_variables to save ~35Mb per `create_s3_toa`.

### DIFF
--- a/openeogeotrellis/collections/sentinel3.py
+++ b/openeogeotrellis/collections/sentinel3.py
@@ -532,7 +532,7 @@ def _read_latlonfile(bbox, latlon_file, lat_band="latitude", lon_band="longitude
         the file containing the latitudes and longitudes
     lat_band : str
         the band containing the latitudes (default=latitude)
-    lon_band : float
+    lon_band : str
         the band containing the longitudes (default=longitude)
 
     Returns
@@ -544,7 +544,14 @@ def _read_latlonfile(bbox, latlon_file, lat_band="latitude", lon_band="longitude
     """
     # getting  geo information
     logger.debug("Reading lat/lon from file %s" % latlon_file)
-    lat_lon_ds = xr.open_dataset(latlon_file).astype("float32")
+    potential_variables = ["elevation_in", "elevation_orphan_in",
+                           "latitude_in", "latitude_orphan_in",
+                           "longitude_in", "longitude_orphan_in",
+                           "latitude_tx", "longitude_tx",
+                           ]
+    to_drop = [x for x in potential_variables if x != lat_band and x != lon_band]  # saves memory
+    # `open_dataarray` could allow for lazy loading, but is more complex and saves the same amount of memory
+    lat_lon_ds = xr.open_dataset(latlon_file, drop_variables=to_drop).astype("float32")
 
     xmin, ymin, xmax, ymax = bbox
 

--- a/tests/data_collections/test_sentinel3.py
+++ b/tests/data_collections/test_sentinel3.py
@@ -4,6 +4,15 @@ import pytest
 from pyproj import CRS
 import rasterio
 
+if __name__ == "__main__":
+    import openeogeotrellis.deploy.local
+
+    # Allow to run from commandline:
+    # /usr/bin/time -v python3 tests/data_collections/test_sentinel3.py
+    # python3 -m memory_profiler tests/data_collections/test_sentinel3.py
+    # The SparkContext is only needed to make imports work, but is actually not used for the tests
+    openeogeotrellis.deploy.local.setup_environment()
+
 from openeogeotrellis.collections.sentinel3 import *
 from numpy.testing import assert_allclose
 
@@ -135,3 +144,8 @@ def test_read_single_edge_with_some_data():
         actual_result = arr
         assert expected_result.shape == actual_result.shape
         assert_allclose(expected_result, actual_result, atol=0.00001)
+
+
+if __name__ == "__main__":
+    # Allow to run from commandline
+    test_read_single()


### PR DESCRIPTION
 https://github.com/Open-EO/openeo-geopyspark-driver/issues/1069
 
 Measured memory usage with:
`python3 -m memory_profiler tests/data_collections/test_sentinel3.py`
```python
import memory_profiler
@memory_profiler.profile()
def read_product(product, product_type, band_names, tile_size, limit_python_memory, resolution):
```

```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================

Original:
   251    335.5 MiB     80.8 MiB           2               orfeo_bands = create_s3_toa(

With drop_variables
   252    299.8 MiB     45.4 MiB           2               orfeo_bands = create_s3_toa(
```