### PR TITLE
Make urllib.error.HTTPError log the URL with the issue.

### DIFF
--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import time
 import traceback
+import urllib
 import uuid
 import importlib.metadata
 from copy import deepcopy
@@ -1166,7 +1167,6 @@ class GeoPySparkBackendImplementation(backend.OpenEoBackendImplementation):
             summary = str_truncate(summary, width=width)
         else:
             is_client_error = False  # Give user the benefit of doubt.
-            import urllib
             if isinstance(error, FileNotFoundError):
                 summary = repr_truncate(str(error), width=width)
             elif isinstance(error, urllib.error.HTTPError):

--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -1166,8 +1166,11 @@ class GeoPySparkBackendImplementation(backend.OpenEoBackendImplementation):
             summary = str_truncate(summary, width=width)
         else:
             is_client_error = False  # Give user the benefit of doubt.
+            import urllib
             if isinstance(error, FileNotFoundError):
                 summary = repr_truncate(str(error), width=width)
+            elif isinstance(error, urllib.error.HTTPError):
+                summary = repr_truncate(str(error) + ": " + error.filename, width=width)
             elif isinstance(error, AssertionError) and str(error) == "":
                 tb = error.__traceback__
                 tb_info = traceback.extract_tb(tb)

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,4 +1,5 @@
 import textwrap
+import urllib
 from unittest import mock
 
 import pytest
@@ -646,6 +647,17 @@ def test_empty_assert_message():
 
     msg = GeoPySparkBackendImplementation.summarize_exception_static(e_info.value).summary
     assert 'srs == "EPSG:4326"' in str(msg)  # assert message should be in the summary
+
+
+def test_HTTPError_404(urllib_mock):
+    fake_url = "http://a.test/404"
+    urllib_mock.get(fake_url, data="404", code=404)
+    from urllib.error import HTTPError
+
+    with pytest.raises(HTTPError) as e_info:
+        urllib.request.urlopen(fake_url)
+    msg = GeoPySparkBackendImplementation.summarize_exception_static(e_info.value).summary
+    assert fake_url in str(msg)
 
 
 @pytest.fixture


### PR DESCRIPTION
No ticket. Just found many errors like this on Kibana: `urllib.error.HTTPError: HTTP Error 404: Not Found`
