### PR TITLE
config: mandate the region for workspaces

### DIFF
--- a/openeogeotrellis/workspace/object_storage_workspace.py
+++ b/openeogeotrellis/workspace/object_storage_workspace.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path, PurePath
-from typing import Union, Optional
+from typing import Union
 from urllib.parse import urlparse
 
 import botocore.exceptions
@@ -22,7 +22,7 @@ class ObjectStorageWorkspace(Workspace):
 
     MULTIPART_THRESHOLD_IN_MB = 50
 
-    def __init__(self, bucket: str, region: Optional[str] = None):
+    def __init__(self, bucket: str, region: str):
         self.bucket = bucket
         self.region = region
         self._stac_io = CustomStacIO()

--- a/tests/backend_config.py
+++ b/tests/backend_config.py
@@ -56,7 +56,7 @@ os.makedirs("/tmp/workspace", exist_ok=True)
 workspaces = {
     "tmp_workspace": DiskWorkspace(root_directory=Path("/tmp/workspace")),
     "tmp": DiskWorkspace(root_directory=Path("/tmp")),
-    "s3_workspace": ObjectStorageWorkspace(bucket="openeo-fake-bucketname"),
+    "s3_workspace": ObjectStorageWorkspace(bucket="openeo-fake-bucketname", region="waw3-1"),
     "s3_workspace_region": ObjectStorageWorkspace(bucket="openeo-fake-eu-nl", region="eu-nl"),
     "stac_api_workspace": _stac_api_workspace(),
 }

--- a/tests/test_object_storage_workspace.py
+++ b/tests/test_object_storage_workspace.py
@@ -19,7 +19,7 @@ def test_import_file(tmp_path, mock_s3_client, mock_s3_bucket, remove_original):
 
     merge = "some/target"
 
-    workspace = ObjectStorageWorkspace(bucket="openeo-fake-bucketname")
+    workspace = ObjectStorageWorkspace(bucket="openeo-fake-bucketname", region="waw3-1")
     workspace_uri = workspace.import_file(
         common_path=source_directory, file=source_file, merge=merge, remove_original=remove_original
     )
@@ -46,7 +46,7 @@ def test_import_object(tmp_path, mock_s3_client, mock_s3_bucket, remove_original
 
     assert _workspace_keys(mock_s3_client, source_bucket, prefix=source_key) == {source_key}
 
-    workspace = ObjectStorageWorkspace(bucket=target_bucket)
+    workspace = ObjectStorageWorkspace(bucket=target_bucket, region="eu-nl")
     workspace_uri = workspace.import_object(
         common_path="some/source/",
         s3_uri=f"s3://{source_bucket}/{source_key}",
@@ -86,7 +86,7 @@ def test_merge_new(mock_s3_client, mock_s3_bucket, tmp_path, remove_original: bo
         s3_client=mock_s3_client,
     )
 
-    workspace = ObjectStorageWorkspace(bucket=target_bucket)
+    workspace = ObjectStorageWorkspace(bucket=target_bucket, region="eu-nl")
     imported_collection = workspace.merge(new_collection, merge, remove_original)
 
     assert isinstance(imported_collection, Collection)
@@ -172,7 +172,7 @@ def test_merge_into_existing(tmp_path, mock_s3_client, mock_s3_bucket, remove_or
         s3_client=mock_s3_client,
     )
 
-    workspace = ObjectStorageWorkspace(target_bucket)
+    workspace = ObjectStorageWorkspace(target_bucket, region="waw3-1")
     workspace.merge(existing_collection, target=merge, remove_original=remove_original)
     imported_collection = workspace.merge(new_collection, target=merge, remove_original=remove_original)
 


### PR DESCRIPTION
Initially the workspace region parameter was optional in order to be able to deploy without breaking existing configs.

The region information is however crucial for correct workspace operation so this change makes it mandatory.