### PR TITLE
disable decode_cf on open_dataset to save memory for sentinel3 #1069

### DIFF
--- a/openeogeotrellis/collections/sentinel3.py
+++ b/openeogeotrellis/collections/sentinel3.py
@@ -572,9 +572,9 @@ def _read_latlonfile(bbox, latlon_file, lat_band="latitude", lon_band="longitude
     lon_offset = lat_lon_ds[lon_band].attrs.get('add_offset', 0.0)
 
     # lat_lon_ds is scaled, so we need to inverse scale the bbox as well.
-    xmin_s, ymin_s, xmax_s, ymax_s = bbox[0]*(1/lon_scale)-lon_offset, bbox[1]*(1/lat_scale)-lat_offset, bbox[2]*(1/lon_scale)-lon_offset, bbox[3]*(1/lat_scale)-lat_offset
-    interpolation_margin_lat = interpolation_margin*(1/lat_scale)-lat_offset
-    interpolation_margin_lon = interpolation_margin*(1/lon_scale)-lon_offset
+    xmin_s, ymin_s, xmax_s, ymax_s = (bbox[0]/lon_scale)-lon_offset, (bbox[1]/lat_scale)-lat_offset, (bbox[2]/lon_scale)-lon_offset, (bbox[3]/lat_scale)-lat_offset
+    interpolation_margin_lat = (interpolation_margin/lat_scale)-lat_offset
+    interpolation_margin_lon = (interpolation_margin/lon_scale)-lon_offset
 
     lat_mask = xr.apply_ufunc(lambda lat: (lat >= ymin_s - interpolation_margin_lat) & (lat <= ymax_s + interpolation_margin_lat), lat_lon_ds[lat_band])
     lon_mask = xr.apply_ufunc(lambda lon: (lon >= xmin_s - interpolation_margin_lon) & (lon <= xmax_s + interpolation_margin_lon), lat_lon_ds[lon_band])

--- a/openeogeotrellis/collections/sentinel3.py
+++ b/openeogeotrellis/collections/sentinel3.py
@@ -562,19 +562,30 @@ def _read_latlonfile(bbox, latlon_file, lat_band="latitude", lon_band="longitude
                            ]
     to_drop = [x for x in potential_variables if x != lat_band and x != lon_band]  # saves memory
     # `open_dataarray` could allow for lazy loading, but is more complex and saves the same amount of memory
-    lat_lon_ds = xr.open_dataset(latlon_file, drop_variables=to_drop).astype("float32")
+    # decode_cf=True forces lat/lon bands from int32 to float64 by filling nans, scaling, and offsetting. This causes OOM errors.
+    # Instead, we do the scaling ourselves. Filling nans is not required for coordinates.
+    # Note that float32 causes us to lose precision, so we stick to int32.
+    lat_lon_ds = xr.open_dataset(latlon_file, drop_variables=to_drop, decode_cf=False)
+    lat_scale = lat_lon_ds[lat_band].attrs.get('scale_factor', 1.0)
+    lat_offset = lat_lon_ds[lat_band].attrs.get('add_offset', 0.0)
+    lon_scale = lat_lon_ds[lon_band].attrs.get('scale_factor', 1.0)
+    lon_offset = lat_lon_ds[lon_band].attrs.get('add_offset', 0.0)
 
-    xmin, ymin, xmax, ymax = bbox
+    # lat_lon_ds is scaled, so we need to inverse scale the bbox as well.
+    xmin_s, ymin_s, xmax_s, ymax_s = bbox[0]*(1/lon_scale)-lon_offset, bbox[1]*(1/lat_scale)-lat_offset, bbox[2]*(1/lon_scale)-lon_offset, bbox[3]*(1/lat_scale)-lat_offset
+    interpolation_margin_lat = interpolation_margin*(1/lat_scale)-lat_offset
+    interpolation_margin_lon = interpolation_margin*(1/lon_scale)-lon_offset
 
-    lat_mask = xr.apply_ufunc(lambda lat: (lat >= ymin - interpolation_margin) & (lat <= ymax + interpolation_margin), lat_lon_ds[lat_band])
-    lon_mask = xr.apply_ufunc(lambda lon: (lon >= xmin - interpolation_margin) & (lon <= xmax + interpolation_margin), lat_lon_ds[lon_band])
+    lat_mask = xr.apply_ufunc(lambda lat: (lat >= ymin_s - interpolation_margin_lat) & (lat <= ymax_s + interpolation_margin_lat), lat_lon_ds[lat_band])
+    lon_mask = xr.apply_ufunc(lambda lon: (lon >= xmin_s - interpolation_margin_lon) & (lon <= xmax_s + interpolation_margin_lon), lat_lon_ds[lon_band])
     data_mask = lat_mask & lon_mask
 
 
     # Create the coordinate arrays for latitude and longitude
     ## Coordinated referring to the CENTER of the pixel
-    lat_orig = lat_lon_ds[lat_band].where(data_mask,drop=True).values
-    lon_orig = lat_lon_ds[lon_band].where(data_mask,drop=True).values
+    # We can rescale to float64 from this point since we are working with smaller arrays.
+    lat_orig = lat_lon_ds[lat_band].where(data_mask, drop=True).values*lat_scale+lat_offset
+    lon_orig = lat_lon_ds[lon_band].where(data_mask, drop=True).values*lon_scale+lon_offset
     lat_lon_ds.close()
 
     if lat_orig.size == 0 or lon_orig.size == 0:
@@ -587,8 +598,8 @@ def _read_latlonfile(bbox, latlon_file, lat_band="latitude", lon_band="longitude
         passing_date_line = True
         # self.lon_orig=np.where(self.lon_orig<0, self.lon_orig+360, self.lon_orig) #change grid from -180->180 to 0->360
 
-    x_min, x_max = np.min(lon_orig), np.max(lon_orig)
-    y_min, y_max = np.min(lat_orig), np.max(lat_orig)
+    x_min, x_max = np.nanmin(lon_orig), np.nanmax(lon_orig)
+    y_min, y_max = np.nanmin(lat_orig), np.nanmax(lat_orig)
     bbox_original = [x_min, y_min, x_max, y_max]
     lon_flat = lon_orig.flatten()
     lat_flat = lat_orig.flatten()


### PR DESCRIPTION
`lat_lon_ds = xr.open_dataset(latlon_file, drop_variables=to_drop, decode_cf=False)`
decode_cf rescales the original netcdf data from int32 to float64 causing OOM errors on the spark executors. By keeping the data as int32 and scaling the bbox instead we can significantly lower memory usage.


Note that this requires an update of `tests/data/binary/sentinel3_edge_ref.tif` reference data. Because we can now work with float64 for lat_orig and lon_orig as these are smaller arrays. Previously we cast everything to float32 while the precision of these NetCDFs is 1e-06 which meant the last digit(s) in some coordinates were rounded. I verified that I get the exact old reference data by just casting these arrays back to float32:
```
lat_orig = lat_orig.astype(np.float32)
lon_orig = lon_orig.astype(np.float32)
```
If required we can cast these to float32 to avoid slightly changing existing workflows.


I went over the decode_cf implementation and verified that the original NetCDF data is not changed in other ways. I did make the assumption that a FillValue will never be required in our usecase, even though the NetCDF does declare a FillValue of -2147483648.