### PR TITLE
feature: Allow S3 presigned urls against S3 proxy

### DIFF
--- a/openeogeotrellis/asset_urls.py
+++ b/openeogeotrellis/asset_urls.py
@@ -1,0 +1,41 @@
+import logging
+from typing import Tuple
+from urllib.parse import urlparse
+
+from openeo_driver.asset_urls import AssetUrl
+from openeogeotrellis.integrations.s3proxy.exceptions import ProxyException
+from openeogeotrellis.integrations.s3proxy.s3 import get_proxy_s3_client_for_job
+from openeogeotrellis.integrations.s3 import create_presigned_url
+
+_log = logging.getLogger(__name__)
+
+
+class PresignedS3AssetUrls(AssetUrl):
+    def __init__(self, expiration: int = 24 * 3600):
+        self._expiration = expiration
+
+    def get(self, asset_metadata: dict, asset_name: str, job_id: str, user_id: str) -> str:
+        href = asset_metadata.get("href")
+        if isinstance(href, str) and href.startswith("s3://"):
+            try:
+                bucket, key = self.get_bucket_key_from_uri(href)
+                return self._get_presigned_url_against_proxy(bucket, key, job_id, user_id)
+            except (ValueError, ProxyException) as e:
+                logging.debug(f"Falling back to default asset getter because: {e}")
+        return super().get(asset_metadata, asset_name, job_id, user_id)
+
+    @staticmethod
+    def get_bucket_key_from_uri(s3_uri: str) -> Tuple[str, str]:
+        _parsed = urlparse(s3_uri, allow_fragments=False)
+        if _parsed.scheme != "s3":
+            raise ValueError(f"Input {s3_uri} is not a valid S3 URI should be of form s3://<bucket>/<key>")
+        bucket = _parsed.netloc
+        if _parsed.query:
+            key = _parsed.path.lstrip('/') + '?' + _parsed.query
+        else:
+            key = _parsed.path.lstrip('/')
+        return bucket, key
+
+    def _get_presigned_url_against_proxy(self, bucket: str, key: str, job_id: str, user_id: str) -> str:
+        s3_client = get_proxy_s3_client_for_job(bucket, job_id, user_id)
+        return create_presigned_url(s3_client, bucket_name=bucket, object_name=key, expiration=self._expiration)

--- a/openeogeotrellis/config/config.py
+++ b/openeogeotrellis/config/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import os
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 import attrs
 from openeo_driver.config import OpenEoBackendConfig, from_env_as_list
@@ -275,3 +275,8 @@ class GpsBackendConfig(OpenEoBackendConfig):
     Directory where config specific to job execution will be mounted for batch jobs.
     """
     batch_job_config_dir: Path = Path("/opt/job_config")
+
+    """
+    A mapping of region names to proxy endpoints
+    """
+    s3_region_proxy_endpoints: Dict[str, str] = attrs.Factory(dict)

--- a/openeogeotrellis/integrations/identity.py
+++ b/openeogeotrellis/integrations/identity.py
@@ -76,6 +76,13 @@ class IDPTokenIssuer:
         else:
             return cls()
 
+    def _hard_reset(self) -> None:
+        """
+        This is only for testing purpose because different tests can actually require different idp config.
+        """
+        self._IDP_DETAILS = None
+        self._reload_idp_details_if_needed()
+
     def _reload_idp_details_if_needed(self) -> None:
         idp_details_file = get_backend_config().openeo_idp_details_file
         register_reload = self.watcher.get_file_reload_register_func_if_changed(idp_details_file)
@@ -132,7 +139,7 @@ def main():
     aws_token_filename = os.environ.get("AWS_TOKEN_FILENAME", "token")
     aws_config_path.mkdir(parents=True, exist_ok=True)
     with open(aws_config_path.joinpath(aws_token_filename), 'w') as token_file:
-        token_file.write(IDP_TOKEN_ISSUER.get_job_token("0", "none"))
+        token_file.write(IDP_TOKEN_ISSUER.get_job_token("0", "none", "j-0"))
 
 
 if __name__ == '__main__':

--- a/openeogeotrellis/integrations/s3/__init__.py
+++ b/openeogeotrellis/integrations/s3/__init__.py
@@ -1,0 +1,2 @@
+from openeogeotrellis.integrations.s3.bucket_details import BucketDetails, is_workspace_bucket
+from openeogeotrellis.integrations.s3.presigned_url import create_presigned_url

--- a/openeogeotrellis/integrations/s3/bucket_details.py
+++ b/openeogeotrellis/integrations/s3/bucket_details.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+from openeogeotrellis.config import get_backend_config
+from openeogeotrellis.workspace.object_storage_workspace import ObjectStorageWorkspace
+
+
+_BUCKET_TYPE_UNKNOWN = "UNKNOWN"
+_BUCKET_TYPE_WORKSPACE = "WORKSPACE"
+_REGION_UNKNOWN = "REGION_UNKNOWN"
+
+
+@dataclass(frozen=True)
+class BucketDetails:
+    name: str
+    region: str = _REGION_UNKNOWN
+    type: str = _BUCKET_TYPE_UNKNOWN
+    type_id: Optional[str] = None
+
+    @classmethod
+    def from_name(cls, bucket_name: str) -> BucketDetails:
+        for ws_name, ws_details in get_backend_config().workspaces.items():
+            if isinstance(ws_details, ObjectStorageWorkspace):
+                if ws_details.bucket == bucket_name:
+                    return cls(
+                        name=bucket_name,
+                        region=ws_details.region,
+                        type=_BUCKET_TYPE_WORKSPACE,
+                        type_id=ws_name
+                    )
+
+        return cls(
+            name=bucket_name,
+        )
+
+
+def is_workspace_bucket(bucket_details: BucketDetails) -> bool:
+    return bucket_details.type == _BUCKET_TYPE_WORKSPACE

--- a/openeogeotrellis/integrations/s3/presigned_url.py
+++ b/openeogeotrellis/integrations/s3/presigned_url.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+from botocore.exceptions import ClientError
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
+
+
+_log = logging.getLogger(__name__)
+
+
+def create_presigned_url(client: S3Client, bucket_name:str, object_name: str, expiration: int=3600) -> Optional[str]:
+    """
+    Generate a presigned URL to share an S3 object
+
+    :return: Presigned URL as string. If error, returns None.
+    """
+    try:
+        response = client.generate_presigned_url(
+            'get_object',
+            Params={'Bucket': bucket_name, 'Key': object_name},
+            ExpiresIn=expiration,
+        )
+    except ClientError as e:
+        logging.info(f"Failed to create presigned url: {e}, continuing without.")
+        return None
+
+    # The response contains the presigned URL
+    return response

--- a/openeogeotrellis/integrations/s3proxy/exceptions.py
+++ b/openeogeotrellis/integrations/s3proxy/exceptions.py
@@ -1,0 +1,14 @@
+class ProxyException(RuntimeError):
+    ...
+
+
+class S3ProxyDisabled(ProxyException):
+    ...
+
+
+class S3ProxyUnsupportedBucketType(ProxyException):
+    ...
+
+
+class DriverCannotIssueTokens(ProxyException):
+    ...

--- a/openeogeotrellis/integrations/s3proxy/s3.py
+++ b/openeogeotrellis/integrations/s3proxy/s3.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
+
+import boto3
+from openeogeotrellis.config import get_backend_config
+from openeogeotrellis.integrations.s3proxy.exceptions import S3ProxyDisabled, S3ProxyUnsupportedBucketType
+from openeogeotrellis.integrations.s3proxy.sts import get_job_aws_credentials_for_proxy
+from openeogeotrellis.integrations.s3 import BucketDetails, is_workspace_bucket
+
+
+def _get_role_arn(bucket_details: BucketDetails) -> str:
+    if is_workspace_bucket(bucket_details):
+        assert bucket_details.type_id is not None
+        return f"arn:openeows:iam:::role/{bucket_details.type_id}"
+    raise S3ProxyUnsupportedBucketType
+
+
+def get_proxy_s3_client_for_job(bucket: str, job_id: str, user_id) -> S3Client:
+    """
+    A proxy S3 client gets a client which is configured for bucket access scoped to an execution context.
+
+    It takes a bucket because a bucket is required to identify the region where the data resides.
+    """
+    bucket_details = BucketDetails.from_name(bucket)
+    region_name = bucket_details.region
+    try:
+        endpoint_url = get_backend_config().s3_region_proxy_endpoints[region_name]
+        creds = get_job_aws_credentials_for_proxy(job_id, user_id, _get_role_arn(bucket_details))
+        return boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            region_name=region_name,
+            **creds.as_client_kwargs()
+        )
+    except KeyError:
+        raise S3ProxyDisabled(f"Region {region_name} is not supported by proxy.")

--- a/openeogeotrellis/integrations/s3proxy/sts.py
+++ b/openeogeotrellis/integrations/s3proxy/sts.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from mypy_boto3_sts.client import STSClient
+    from mypy_boto3_sts.type_defs import CredentialsTypeDef
+
+import os
+import boto3
+from openeogeotrellis.integrations.identity import IDP_TOKEN_ISSUER
+from openeogeotrellis.integrations.s3proxy.exceptions import S3ProxyDisabled, DriverCannotIssueTokens
+from openeogeotrellis.config.s3_config import AWSConfig
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class STSCredentials:
+    access_key_id: str
+    secret_access_key: str
+    session_token: str
+    expiration: datetime
+
+    @classmethod
+    def from_sts_response_creds(cls, creds: CredentialsTypeDef) -> STSCredentials:
+        return cls(
+            access_key_id=creds["AccessKeyId"],
+            secret_access_key=creds["SecretAccessKey"],
+            session_token=creds["SessionToken"],
+            expiration=creds["Expiration"]
+        )
+
+    def as_client_kwargs(self):
+        return {
+            "aws_access_key_id": self.access_key_id,
+            "aws_secret_access_key": self.secret_access_key,
+            "aws_session_token": self.session_token
+        }
+
+
+class _STSClient:
+    """Because moto does not support custom endpoints"""
+    @classmethod
+    def get(cls, *args, **kwargs) -> STSClient:
+        return boto3.client("sts", *args, **kwargs)
+
+def _get_environment_sts_endpoint() -> str:
+    endpoint = os.environ.get(AWSConfig.S3PROXY_STS_ENDPOINT_URL, "disabled").lower()
+    if endpoint == "disabled":
+        raise S3ProxyDisabled("No STS endpoint")
+    return endpoint
+
+def _get_proxy_sts_client() -> STSClient:
+    return _STSClient.get(endpoint_url=_get_environment_sts_endpoint())
+
+
+def _get_aws_credentials_for_proxy(token: str, role_arn: str, session_name: Optional[str] = None) -> STSCredentials:
+    session_name = session_name or "openeo-geopyspark-driver"
+    sts = _get_proxy_sts_client()
+    return STSCredentials.from_sts_response_creds(
+        sts.assume_role_with_web_identity(
+            RoleArn=role_arn,
+            RoleSessionName=session_name,
+            WebIdentityToken=token
+        )["Credentials"]
+    )
+
+def get_job_aws_credentials_for_proxy(
+        job_id: str, user_id: str, role_arn: str, session_name: Optional[str] = None
+) -> STSCredentials:
+    token = IDP_TOKEN_ISSUER.get_job_token(sub_id="openeo-driver", user_id=user_id, job_id=job_id)
+    if token is None:
+        raise DriverCannotIssueTokens()
+    return _get_aws_credentials_for_proxy(
+        token=token,
+        role_arn=role_arn,
+        session_name=session_name
+    )

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,11 @@ tests_require = [
     "pydantic~=1.0",
 ]
 
+typing_require = [
+    'mypy-boto3-sts',
+    'mypy-boto3-s3',
+]
+
 setup(
     name='openeo-geopyspark',
     version=version,
@@ -107,7 +112,7 @@ setup(
         "importlib_resources; python_version<'3.9'",  # #1060 on python 3.8 we need importlib_resources backport
     ],
     extras_require={
-        "dev": tests_require,
+        "dev": tests_require + typing_require,
         "k8s": [
             "kubernetes",
             "PyYAML",

--- a/tests/backend_config.py
+++ b/tests/backend_config.py
@@ -56,7 +56,7 @@ os.makedirs("/tmp/workspace", exist_ok=True)
 workspaces = {
     "tmp_workspace": DiskWorkspace(root_directory=Path("/tmp/workspace")),
     "tmp": DiskWorkspace(root_directory=Path("/tmp")),
-    "s3_workspace": ObjectStorageWorkspace(bucket="openeo-fake-bucketname", region="waw3-1"),
+    "s3_workspace": ObjectStorageWorkspace(bucket="openeo-fake-bucketname", region="eu-central-1"),
     "s3_workspace_region": ObjectStorageWorkspace(bucket="openeo-fake-eu-nl", region="eu-nl"),
     "stac_api_workspace": _stac_api_workspace(),
 }

--- a/tests/test_s3_config.py
+++ b/tests/test_s3_config.py
@@ -6,12 +6,10 @@ from openeogeotrellis.config.s3_config import S3Config, AwsProfileDetails, AWSCo
 from configparser import ConfigParser
 
 
-def test_rendered_config_is_parseable(monkeypatch):
+def test_rendered_config_is_parseable(monkeypatch, sts_endpoint_on_driver):
     # Given S3Proxy endpoints
-    sts_endpoint = "my-sts.example.com"
     s3_endpoint = "s3.example.com"
     monkeypatch.setenv(AWSConfig.S3PROXY_S3_ENDPOINT_URL, s3_endpoint)
-    monkeypatch.setenv(AWSConfig.S3PROXY_STS_ENDPOINT_URL, sts_endpoint)
 
     # Given profile details
     test_profile_name = "test"
@@ -48,7 +46,7 @@ def test_rendered_config_is_parseable(monkeypatch):
     # Then services section must be there
     services_section_name = f"services {AWSConfig.S3PROXY_SERVICES}"
     assert "\nendpoint_url" in cp.get(services_section_name, "sts")
-    assert sts_endpoint in cp.get(services_section_name, "sts")
+    assert sts_endpoint_on_driver in cp.get(services_section_name, "sts")
     assert "\nendpoint_url" in cp.get(services_section_name, "s3")
     assert s3_endpoint in cp.get(services_section_name, "s3")
 


### PR DESCRIPTION
If the geopyspark-driver has config set to be able to issue IDP tokens and the STS endpoint as well as a new config `s3_region_proxy_endpoints` which has the S3 proxy endpoint per region then it will generate presigned S3 urls for assets as long as it knows about the asset buckets via a workspace.