### PR TITLE
Feature/s3 assets via s3 proxy

### DIFF
--- a/openeogeotrellis/asset_urls.py
+++ b/openeogeotrellis/asset_urls.py
@@ -1,0 +1,41 @@
+import logging
+from typing import Tuple
+from urllib.parse import urlparse
+
+from openeo_driver.asset_urls import AssetUrl
+from openeogeotrellis.integrations.s3proxy.exceptions import ProxyException
+from openeogeotrellis.integrations.s3proxy.s3 import get_proxy_s3_client_for_job
+from openeogeotrellis.integrations.s3 import create_presigned_url
+
+_log = logging.getLogger(__name__)
+
+
+class PresignedS3AssetUrls(AssetUrl):
+    def __init__(self, expiration: int = 24 * 3600):
+        self._expiration = expiration
+
+    def get(self, asset_metadata: dict, asset_name: str, job_id: str, user_id: str) -> str:
+        href = asset_metadata.get("href")
+        if isinstance(href, str) and href.startswith("s3://"):
+            try:
+                bucket, key = self.get_bucket_key_from_uri(href)
+                return self._get_presigned_url_against_proxy(bucket, key, job_id, user_id)
+            except (ValueError, ProxyException) as e:
+                logging.debug(f"Falling back to default asset getter because: {e}")
+        return super().get(asset_metadata, asset_name, job_id, user_id)
+
+    @staticmethod
+    def get_bucket_key_from_uri(s3_uri: str) -> Tuple[str, str]:
+        _parsed = urlparse(s3_uri, allow_fragments=False)
+        if _parsed.scheme != "s3":
+            raise ValueError(f"Input {s3_uri} is not a valid S3 URI should be of form s3://<bucket>/<key>")
+        bucket = _parsed.netloc
+        if _parsed.query:
+            key = _parsed.path.lstrip('/') + '?' + _parsed.query
+        else:
+            key = _parsed.path.lstrip('/')
+        return bucket, key
+
+    def _get_presigned_url_against_proxy(self, bucket: str, key: str, job_id: str, user_id: str) -> str:
+        s3_client = get_proxy_s3_client_for_job(bucket, job_id, user_id)
+        return create_presigned_url(s3_client, bucket_name=bucket, object_name=key, expiration=self._expiration)

--- a/openeogeotrellis/asset_urls.py
+++ b/openeogeotrellis/asset_urls.py
@@ -14,7 +14,7 @@ class PresignedS3AssetUrls(AssetUrl):
     def __init__(self, expiration: int = 24 * 3600):
         self._expiration = expiration
 
-    def get(self, asset_metadata: dict, asset_name: str, job_id: str, user_id: str) -> str:
+    def build_url(self, *, asset_metadata: dict, asset_name: str, job_id: str, user_id: str) -> str:
         href = asset_metadata.get("href")
         if isinstance(href, str) and href.startswith("s3://"):
             try:
@@ -22,7 +22,7 @@ class PresignedS3AssetUrls(AssetUrl):
                 return self._get_presigned_url_against_proxy(bucket, key, job_id, user_id)
             except (ValueError, ProxyException) as e:
                 logging.debug(f"Falling back to default asset getter because: {e}")
-        return super().get(asset_metadata, asset_name, job_id, user_id)
+        return super().build_url(asset_metadata=asset_metadata, asset_name=asset_name, job_id=job_id, user_id=user_id)
 
     @staticmethod
     def get_bucket_key_from_uri(s3_uri: str) -> Tuple[str, str]:

--- a/openeogeotrellis/config/config.py
+++ b/openeogeotrellis/config/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import os
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 import attrs
 from openeo_driver.config import OpenEoBackendConfig, from_env_as_list
@@ -275,3 +275,8 @@ class GpsBackendConfig(OpenEoBackendConfig):
     Directory where config specific to job execution will be mounted for batch jobs.
     """
     batch_job_config_dir: Path = Path("/opt/job_config")
+
+    """
+    A mapping of region names to proxy endpoints
+    """
+    s3_region_proxy_endpoints: Dict[str, str] = attrs.Factory(dict)

--- a/openeogeotrellis/integrations/identity.py
+++ b/openeogeotrellis/integrations/identity.py
@@ -77,6 +77,13 @@ class IDPTokenIssuer:
         else:
             return cls()
 
+    def _hard_reset(self) -> None:
+        """
+        This is only for testing purpose because different tests can actually require different idp config.
+        """
+        self._IDP_DETAILS = None
+        self._reload_idp_details_if_needed()
+
     def _reload_idp_details_if_needed(self) -> None:
         idp_details_file = get_backend_config().openeo_idp_details_file
         register_reload = self.watcher.get_file_reload_register_func_if_changed(idp_details_file)
@@ -133,7 +140,7 @@ def main():
     aws_token_filename = os.environ.get("AWS_TOKEN_FILENAME", "token")
     aws_config_path.mkdir(parents=True, exist_ok=True)
     with open(aws_config_path.joinpath(aws_token_filename), 'w') as token_file:
-        token_file.write(IDP_TOKEN_ISSUER.get_job_token("0", "none"))
+        token_file.write(IDP_TOKEN_ISSUER.get_job_token("0", "none", "j-0"))
 
 
 if __name__ == '__main__':

--- a/openeogeotrellis/integrations/s3/__init__.py
+++ b/openeogeotrellis/integrations/s3/__init__.py
@@ -1,0 +1,2 @@
+from openeogeotrellis.integrations.s3.bucket_details import BucketDetails, is_workspace_bucket
+from openeogeotrellis.integrations.s3.presigned_url import create_presigned_url

--- a/openeogeotrellis/integrations/s3/bucket_details.py
+++ b/openeogeotrellis/integrations/s3/bucket_details.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+from openeogeotrellis.config import get_backend_config
+from openeogeotrellis.workspace.object_storage_workspace import ObjectStorageWorkspace
+
+
+_BUCKET_TYPE_UNKNOWN = "UNKNOWN"
+_BUCKET_TYPE_WORKSPACE = "WORKSPACE"
+_REGION_UNKNOWN = "REGION_UNKNOWN"
+
+
+@dataclass(frozen=True)
+class BucketDetails:
+    name: str
+    region: str = _REGION_UNKNOWN
+    type: str = _BUCKET_TYPE_UNKNOWN
+    type_id: Optional[str] = None
+
+    @classmethod
+    def from_name(cls, bucket_name: str) -> BucketDetails:
+        for ws_name, ws_details in get_backend_config().workspaces.items():
+            if isinstance(ws_details, ObjectStorageWorkspace):
+                if ws_details.bucket == bucket_name:
+                    return cls(
+                        name=bucket_name,
+                        region=ws_details.region,
+                        type=_BUCKET_TYPE_WORKSPACE,
+                        type_id=ws_name
+                    )
+
+        return cls(
+            name=bucket_name,
+        )
+
+
+def is_workspace_bucket(bucket_details: BucketDetails) -> bool:
+    return bucket_details.type == _BUCKET_TYPE_WORKSPACE

--- a/openeogeotrellis/integrations/s3/presigned_url.py
+++ b/openeogeotrellis/integrations/s3/presigned_url.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+from botocore.exceptions import ClientError
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
+
+
+_log = logging.getLogger(__name__)
+
+
+def create_presigned_url(client: S3Client, bucket_name:str, object_name: str, expiration: int=3600) -> Optional[str]:
+    """
+    Generate a presigned URL to share an S3 object
+
+    :return: Presigned URL as string. If error, returns None.
+    """
+    try:
+        response = client.generate_presigned_url(
+            'get_object',
+            Params={'Bucket': bucket_name, 'Key': object_name},
+            ExpiresIn=expiration,
+        )
+    except ClientError as e:
+        logging.info(f"Failed to create presigned url: {e}, continuing without.")
+        return None
+
+    # The response contains the presigned URL
+    return response

--- a/openeogeotrellis/integrations/s3proxy/exceptions.py
+++ b/openeogeotrellis/integrations/s3proxy/exceptions.py
@@ -1,0 +1,14 @@
+class ProxyException(RuntimeError):
+    ...
+
+
+class S3ProxyDisabled(ProxyException):
+    ...
+
+
+class S3ProxyUnsupportedBucketType(ProxyException):
+    ...
+
+
+class DriverCannotIssueTokens(ProxyException):
+    ...

--- a/openeogeotrellis/integrations/s3proxy/s3.py
+++ b/openeogeotrellis/integrations/s3proxy/s3.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
+
+import boto3
+from openeogeotrellis.config import get_backend_config
+from openeogeotrellis.integrations.s3proxy.exceptions import S3ProxyDisabled, S3ProxyUnsupportedBucketType
+from openeogeotrellis.integrations.s3proxy.sts import get_job_aws_credentials_for_proxy
+from openeogeotrellis.integrations.s3 import BucketDetails, is_workspace_bucket
+
+
+def _get_role_arn(bucket_details: BucketDetails) -> str:
+    if is_workspace_bucket(bucket_details):
+        assert bucket_details.type_id is not None
+        return f"arn:openeows:iam:::role/{bucket_details.type_id}"
+    raise S3ProxyUnsupportedBucketType
+
+
+def get_proxy_s3_client_for_job(bucket: str, job_id: str, user_id) -> S3Client:
+    """
+    A proxy S3 client gets a client which is configured for bucket access scoped to an execution context.
+
+    It takes a bucket because a bucket is required to identify the region where the data resides.
+    """
+    bucket_details = BucketDetails.from_name(bucket)
+    region_name = bucket_details.region
+    try:
+        endpoint_url = get_backend_config().s3_region_proxy_endpoints[region_name]
+        creds = get_job_aws_credentials_for_proxy(job_id, user_id, _get_role_arn(bucket_details))
+        return boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            region_name=region_name,
+            **creds.as_client_kwargs()
+        )
+    except KeyError:
+        raise S3ProxyDisabled(f"Region {region_name} is not supported by proxy.")

--- a/openeogeotrellis/integrations/s3proxy/sts.py
+++ b/openeogeotrellis/integrations/s3proxy/sts.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from mypy_boto3_sts.client import STSClient
+    from mypy_boto3_sts.type_defs import CredentialsTypeDef
+
+import os
+import boto3
+from openeogeotrellis.integrations.identity import IDP_TOKEN_ISSUER
+from openeogeotrellis.integrations.s3proxy.exceptions import S3ProxyDisabled, DriverCannotIssueTokens
+from openeogeotrellis.config.s3_config import AWSConfig
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class STSCredentials:
+    access_key_id: str
+    secret_access_key: str
+    session_token: str
+    expiration: datetime
+
+    @classmethod
+    def from_sts_response_creds(cls, creds: CredentialsTypeDef) -> STSCredentials:
+        return cls(
+            access_key_id=creds["AccessKeyId"],
+            secret_access_key=creds["SecretAccessKey"],
+            session_token=creds["SessionToken"],
+            expiration=creds["Expiration"]
+        )
+
+    def as_client_kwargs(self):
+        return {
+            "aws_access_key_id": self.access_key_id,
+            "aws_secret_access_key": self.secret_access_key,
+            "aws_session_token": self.session_token
+        }
+
+
+class _STSClient:
+    """Because moto does not support custom endpoints"""
+    @classmethod
+    def get(cls, *args, **kwargs) -> STSClient:
+        return boto3.client("sts", *args, **kwargs)
+
+def _get_environment_sts_endpoint() -> str:
+    endpoint = os.environ.get(AWSConfig.S3PROXY_STS_ENDPOINT_URL, "disabled").lower()
+    if endpoint == "disabled":
+        raise S3ProxyDisabled("No STS endpoint")
+    return endpoint
+
+def _get_proxy_sts_client() -> STSClient:
+    return _STSClient.get(endpoint_url=_get_environment_sts_endpoint())
+
+
+def _get_aws_credentials_for_proxy(token: str, role_arn: str, session_name: Optional[str] = None) -> STSCredentials:
+    session_name = session_name or "openeo-geopyspark-driver"
+    sts = _get_proxy_sts_client()
+    return STSCredentials.from_sts_response_creds(
+        sts.assume_role_with_web_identity(
+            RoleArn=role_arn,
+            RoleSessionName=session_name,
+            WebIdentityToken=token
+        )["Credentials"]
+    )
+
+def get_job_aws_credentials_for_proxy(
+        job_id: str, user_id: str, role_arn: str, session_name: Optional[str] = None
+) -> STSCredentials:
+    token = IDP_TOKEN_ISSUER.get_job_token(sub_id="openeo-driver", user_id=user_id, job_id=job_id)
+    if token is None:
+        raise DriverCannotIssueTokens()
+    return _get_aws_credentials_for_proxy(
+        token=token,
+        role_arn=role_arn,
+        session_name=session_name
+    )

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,11 @@ tests_require = [
     "pydantic~=1.0",
 ]
 
+typing_require = [
+    'mypy-boto3-sts',
+    'mypy-boto3-s3',
+]
+
 setup(
     name='openeo-geopyspark',
     version=version,
@@ -107,7 +112,7 @@ setup(
         "importlib_resources; python_version<'3.9'",  # #1060 on python 3.8 we need importlib_resources backport
     ],
     extras_require={
-        "dev": tests_require,
+        "dev": tests_require + typing_require,
         "k8s": [
             "kubernetes",
             "PyYAML",

--- a/tests/backend_config.py
+++ b/tests/backend_config.py
@@ -56,7 +56,7 @@ os.makedirs("/tmp/workspace", exist_ok=True)
 workspaces = {
     "tmp_workspace": DiskWorkspace(root_directory=Path("/tmp/workspace")),
     "tmp": DiskWorkspace(root_directory=Path("/tmp")),
-    "s3_workspace": ObjectStorageWorkspace(bucket="openeo-fake-bucketname", region="waw3-1"),
+    "s3_workspace": ObjectStorageWorkspace(bucket="openeo-fake-bucketname", region="eu-central-1"),
     "s3_workspace_region": ObjectStorageWorkspace(bucket="openeo-fake-eu-nl", region="eu-nl"),
     "stac_api_workspace": _stac_api_workspace(),
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,28 @@
 import contextlib
 import importlib
+import json
 import os
 import shutil
 import sys
 import typing
-import urllib
 from datetime import datetime
 from pathlib import Path
-from typing import Union
+from typing import Optional
 from unittest import mock
 
 import boto3
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
 import flask
 import moto
 import moto.server
+import openeo_driver
+from openeo_driver.config import OpenEoBackendConfig
+from openeogeotrellis.integrations.identity import IDPTokenIssuer
+
+from openeogeotrellis.config.s3_config import AWSConfig
+
+import openeogeotrellis
 import pytest
 import requests_mock
 import time_machine
@@ -24,7 +33,8 @@ from openeo_driver.testing import ApiTester, ephemeral_fileserver, UrllibMocker
 from openeo_driver.utils import smart_bool
 from openeo_driver.views import build_app
 
-from openeogeotrellis.config import get_backend_config
+from openeogeotrellis.integrations.s3proxy.sts import _STSClient
+from openeogeotrellis.config import get_backend_config, GpsBackendConfig
 from openeogeotrellis.job_registry import InMemoryJobRegistry
 from openeogeotrellis.testing import gps_config_overrides
 from openeogeotrellis.vault import Vault
@@ -300,14 +310,64 @@ def job_registry() -> InMemoryJobRegistry:
 
 
 @pytest.fixture
-def backend_implementation(batch_job_output_root, job_registry) -> "GeoPySparkBackendImplementation":
+def _dynamic_overrides(idp_config_file) -> typing.Generator[dict, None, None]:
+    """
+    Some overrides are generated files and need to be in config. Those will require handling in here
+    """
+    overrides = {}
+    if idp_config_file is not None:
+        overrides["openeo_idp_details_file"] = idp_config_file
+    if moto_server_address is not None:
+        overrides["s3_region_proxy_endpoints"] = {
+            "eu-central-1": moto_server_address
+        }
+    yield overrides
+
+
+@pytest.fixture
+def config_overrides() -> dict:
+    # Default implementation does not have overrides
+    return {}
+
+
+@pytest.fixture
+def _config_overrides(config_overrides, _dynamic_overrides) -> dict:
+    # use config_overrides to set manual overrides for your test
+    return {
+        **_dynamic_overrides,
+        **config_overrides
+    }
+
+
+@pytest.fixture
+def set_config_overrides(_config_overrides) -> typing.Generator[GpsBackendConfig, None, None]:
+    openeo_driver_overrides = {}
+    for config_key, config_override_value in _config_overrides.items():
+        if hasattr(OpenEoBackendConfig, config_key):
+            openeo_driver_overrides[config_key] = config_override_value
+
+    geopyspark_driver_overrides = {}
+    for config_key, config_override_value in _config_overrides.items():
+        if hasattr(OpenEoBackendConfig, config_key):
+            openeo_driver_overrides[config_key] = config_override_value
+        elif hasattr(openeogeotrellis.config.GpsBackendConfig, config_key):
+            geopyspark_driver_overrides[config_key] = config_override_value
+        else:
+            raise ValueError(f"config value {config_key} cannot be attributed to a config")
+    with openeo_driver.testing.config_overrides(**openeo_driver_overrides):
+        with openeogeotrellis.testing.gps_config_overrides(**geopyspark_driver_overrides, **openeo_driver_overrides):
+            yield get_backend_config()
+
+
+@pytest.fixture
+def backend_implementation(batch_job_output_root, job_registry, set_config_overrides) -> "GeoPySparkBackendImplementation":
     from openeogeotrellis.backend import GeoPySparkBackendImplementation
 
     backend = GeoPySparkBackendImplementation(
         batch_job_output_root=batch_job_output_root,
         elastic_job_registry=job_registry,
     )
-    return backend
+    yield backend
 
 
 @pytest.fixture
@@ -391,14 +451,40 @@ def aws_credentials(monkeypatch):
 
 @pytest.fixture(scope="function")
 def mock_s3_resource(aws_credentials):
-    with moto.mock_aws():
-        yield boto3.resource("s3", region_name=TEST_AWS_REGION_NAME)
-
+    if moto_server_address is None:
+        with moto.mock_aws():
+            yield boto3.resource("s3", region_name=TEST_AWS_REGION_NAME)
+    else:
+        yield boto3.resource("s3", region_name=TEST_AWS_REGION_NAME, endpoint_url=moto_server_address)
 
 @pytest.fixture(scope="function")
 def mock_s3_client(aws_credentials):
-    with moto.mock_aws():
-        yield boto3.client("s3", region_name=TEST_AWS_REGION_NAME)
+    if moto_server_address is None:
+        with moto.mock_aws():
+            yield boto3.client("s3", region_name=TEST_AWS_REGION_NAME)
+    else:
+        yield boto3.client("s3", region_name=TEST_AWS_REGION_NAME, endpoint_url=moto_server_address)
+
+@pytest.fixture(scope="function")
+def mock_sts_client(monkeypatch):
+    # Because moto does not support custom endpoints for sts we need to monkeypatch
+    if moto_server_address is None:
+        with moto.mock_aws():
+            sts_client = boto3.client("sts")
+
+            def getter(*_, **_2):
+                return sts_client
+
+            monkeypatch.setattr(_STSClient, "get", getter)
+            yield sts_client
+    else:
+        sts_client = boto3.client("sts", endpoint_url=moto_server_address)
+
+        def getter(*args, **kwargs):
+            return sts_client
+
+        monkeypatch.setattr(_STSClient, "get", getter)
+        yield sts_client
 
 
 @pytest.fixture(scope="function")
@@ -414,8 +500,11 @@ def mock_s3_bucket(mock_s3_resource, monkeypatch):
         yield bucket
 
 
-@pytest.fixture
-def moto_server(monkeypatch) -> str:
+moto_server_address: Optional[str] = None
+
+
+@pytest.fixture(scope="function")
+def moto_server(monkeypatch) -> typing.Generator[str, None, None]:
     """
     Fixture to run Moto in server mode,
     so that subprocesses also can access mocked services
@@ -426,10 +515,28 @@ def moto_server(monkeypatch) -> str:
         port=0,
     )
     server.start()
+    global moto_server_address
+    old_moto_server_address = moto_server_address
     endpoint_url = f"http://{server._server.server_address[0]}:{server._server.server_port}"
     monkeypatch.setenv("SWIFT_URL", endpoint_url)
+    moto_server_address = endpoint_url.replace("0.0.0.0", "127.0.0.1")
     yield endpoint_url
+    # moto_server cleanup is not reliable if in single process
+    _destroy_all_s3_resources(moto_server_address)
+    moto_server_address = old_moto_server_address
     server.stop()
+
+
+def _destroy_all_s3_resources(endpoint):
+    assert "http://127.0.0.1:" in endpoint, "We are not going S3 resource not on localhost"
+    c = boto3.client("s3", region_name=TEST_AWS_REGION_NAME, endpoint_url=endpoint)
+    try:
+        for bucket in c.list_buckets()["Buckets"]:
+            b = boto3.resource("s3", region_name=TEST_AWS_REGION_NAME, endpoint_url=endpoint).Bucket(bucket["Name"])
+            b.objects.all().delete()
+            b.delete()
+    except KeyError:
+        print("Nothing to cleanup")
 
 
 @pytest.fixture
@@ -482,6 +589,62 @@ def unload_dummy_packages():
         if package in sys.modules:
             del sys.modules[package]
     importlib.invalidate_caches()
+
+
+@pytest.fixture
+def sts_endpoint_on_driver(monkeypatch) -> typing.Generator[str, None, None]:
+    """Make sure the driver is configured for using proxy STS endpoint"""
+    sts_endpoint = "https://sts.oeo.net"
+    monkeypatch.setenv(AWSConfig.S3PROXY_STS_ENDPOINT_URL, sts_endpoint)
+    yield sts_endpoint
+
+
+@pytest.fixture
+def idp_enabled() -> bool:
+    """By default we do not have IDP config available"""
+    return False
+
+
+def create_test_idp_config() -> typing.Dict[str, str]:
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048
+    )
+
+    pem_private_key = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption()
+    )
+
+    pem_public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.PKCS1
+    )
+
+    return {
+        "issuer": "ipd.oeo.net",
+        "private_key": pem_private_key.decode("utf-8"),
+        "public_key": pem_public_key.decode("utf-8")
+    }
+
+
+@pytest.fixture
+def idp_config_file(idp_enabled, tmp_path) -> typing.Generator[Optional[Path], None, None]:
+    """
+    This fixture is called automatically and if idp_enabled is set to true then it will create a IDP config file
+    and make sure the backend_config finds the config file.
+    """
+    if not idp_enabled:
+        # The default does not have config anyway
+        IDPTokenIssuer.instance()._hard_reset()
+        yield None
+    else:
+        idp_file = tmp_path / "idp_details.json"
+        with open(idp_file, "w") as outf:
+            outf.write(json.dumps(create_test_idp_config()))
+        IDPTokenIssuer.instance()._hard_reset()
+        yield idp_file
 
 
 @pytest.fixture

--- a/tests/test_s3_config.py
+++ b/tests/test_s3_config.py
@@ -6,12 +6,10 @@ from openeogeotrellis.config.s3_config import S3Config, AwsProfileDetails, AWSCo
 from configparser import ConfigParser
 
 
-def test_rendered_config_is_parseable(monkeypatch):
+def test_rendered_config_is_parseable(monkeypatch, sts_endpoint_on_driver):
     # Given S3Proxy endpoints
-    sts_endpoint = "my-sts.example.com"
     s3_endpoint = "s3.example.com"
     monkeypatch.setenv(AWSConfig.S3PROXY_S3_ENDPOINT_URL, s3_endpoint)
-    monkeypatch.setenv(AWSConfig.S3PROXY_STS_ENDPOINT_URL, sts_endpoint)
 
     # Given profile details
     test_profile_name = "test"
@@ -48,7 +46,7 @@ def test_rendered_config_is_parseable(monkeypatch):
     # Then services section must be there
     services_section_name = f"services {AWSConfig.S3PROXY_SERVICES}"
     assert "\nendpoint_url" in cp.get(services_section_name, "sts")
-    assert sts_endpoint in cp.get(services_section_name, "sts")
+    assert sts_endpoint_on_driver in cp.get(services_section_name, "sts")
     assert "\nendpoint_url" in cp.get(services_section_name, "s3")
     assert s3_endpoint in cp.get(services_section_name, "s3")
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1003,7 +1003,7 @@ class TestBatchJobs:
 
                 assert res.status_code == expected_code
                 if 200 <= expected_code < 300:
-                    # For succesfull api requests check response data
+                    # For successfull api requests check response data
                     assert res.data == TIFF_DUMMY_DATA
 
     @mock.patch(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -14,6 +14,7 @@ from unittest import mock
 import boto3
 import kazoo.exceptions
 import pytest
+import requests
 import time_machine
 from elasticsearch.exceptions import ConnectionTimeout
 from openeo.util import deep_get
@@ -31,6 +32,7 @@ from openeo_driver.testing import (
 
 import openeogeotrellis.job_registry
 import openeogeotrellis.sentinel_hub.batchprocessing
+from openeogeotrellis.asset_urls import PresignedS3AssetUrls
 from openeogeotrellis.backend import JOB_METADATA_FILENAME, GpsBatchJobs
 from openeogeotrellis.job_registry import DoubleJobRegistry, ZkJobRegistry
 from openeogeotrellis.testing import KazooClientMock, gps_config_overrides
@@ -836,6 +838,159 @@ class TestBatchJobs:
                 res = api.client.get(download_url, headers=TEST_USER_AUTH_HEADER)
                 assert res.status_code == 200
                 assert res.data == TIFF_DUMMY_DATA
+
+    @mock.patch(
+        "openeogeotrellis.configparams.ConfigParams.use_object_storage",
+        new_callable=mock.PropertyMock,
+    )
+    @pytest.mark.parametrize(
+        "config_overrides,idp_enabled,auth_header,expected_code", [
+            # When using the new PresignedS3AssetUrls with required config in place we should never fail
+            [
+                {
+                    "asset_url": PresignedS3AssetUrls()
+                }, True, False, 200
+            ],
+            [
+                {
+                    "asset_url": PresignedS3AssetUrls()
+                }, True, True, 200
+            ],
+            # When using the new PresignedS3AssetUrls without having the required config in place for IDP
+            # we should not fail so if request occur like before (auth header present) it works, without if fails
+            [
+                {
+                    "asset_url": PresignedS3AssetUrls(),
+                }, False, True, 200
+            ],
+            [
+                {
+                    "asset_url": PresignedS3AssetUrls(),
+                }, False, False, 401
+            ],
+            # When using the new PresignedS3AssetUrls without having the required config in place we should not fail
+            # so if request occur like before (auth header present) it works, without if fails
+            [
+                {
+                    "asset_url": PresignedS3AssetUrls(),
+                    "s3_region_proxy_endpoints": {},  # Mimic no proxy configured
+                }, False, True, 200
+            ],
+            [
+                {
+                    "asset_url": PresignedS3AssetUrls(),
+                    "s3_region_proxy_endpoints": {},  # Mimic no proxy configured
+                }, False, False, 401
+            ],
+            [{}, False, True, 200],  # Old signer works if auth header is used
+            [{}, False, False, 401],  # Old signer fails if auth header not used for retrieval
+        ]
+
+    )
+    def test_download_from_object_storage_via_proxy(
+        self, mock_config_use_object_storage, moto_server, batch_job_output_root, mock_s3_bucket, mock_sts_client,
+        sts_endpoint_on_driver, api, config_overrides, idp_enabled, auth_header: bool, expected_code: int
+    ):
+        """Test the scenario where the result files we want to download are stored on the objects storage,
+        but they are not present in the container that receives the download request.
+
+        Namely: the pod/container that ran the job has been replaced => new container, no files there.
+        Because there is an S3 proxy it will be downloaded straight.
+        """
+
+        mock_config_use_object_storage.return_value = True
+        job_id = "6d11e901-bb5d-4589-b600-8dfb50524740"
+        job_dir: pathlib.Path = batch_job_output_root / job_id
+        output_dir_s3_url = to_s3_url(job_dir)
+        job_metadata = (job_dir / JOB_METADATA_FILENAME)
+
+        job_metadata_contents = {
+            'geometry': {
+                'type':
+                'Polygon',
+                'coordinates': [[[2.0, 51.0], [2.0, 52.0], [3.0, 52.0],
+                                 [3.0, 51.0], [2.0, 51.0]]]
+            },
+            'bbox': [2, 51, 3, 52],
+            'start_datetime': '2017-11-21T00:00:00Z',
+            'end_datetime': '2017-11-21T00:00:00Z',
+            'links': [],
+            'assets': {
+                'openEO_2017-11-21Z.tif': {
+                    'href': f'{output_dir_s3_url}/openEO_2017-11-21Z.tif',
+                    'output_dir': output_dir_s3_url,  # Will not exist on the local file system at download time.
+                    'type': 'image/tiff; application=geotiff',
+                    'roles': ['data'],
+                    'bands': [{
+                        'name': 'ndvi',
+                        'common_name': None,
+                        'wavelength_um': None
+                    }],
+                    'nodata': 255
+                }
+            },
+            'epsg': 4326,
+            'instruments': [],
+            'processing:facility': 'VITO - SPARK',
+            'processing:software': 'openeo-geotrellis-0.3.3a1'
+        }
+
+        mock_s3_bucket.put_object(Key=str(job_metadata).strip("/"), Body=json.dumps(job_metadata_contents))
+        output_file = str(job_dir / "openEO_2017-11-21Z.tif")
+        mock_s3_bucket.put_object(Key=output_file.lstrip("/"), Body=TIFF_DUMMY_DATA)
+
+        # Do a pre-test check: Make sure we are testing that it works when the job_dir is **not** present.
+        # Otherwise the test may pass but it passes for the wrong reasons.
+        assert not job_dir.exists()
+
+        with self._mock_kazoo_client() as zk:
+            # where to import dict_no_none from
+            data = api.get_process_graph_dict(self.DUMMY_PROCESS_GRAPH, title="Dummy")
+            job_options = {}
+
+            # TODO #236/#498/#632 eliminate direct dependency on deprecated ZkJobRegistry and related mocking (e.g. `self._mock_kazoo_client()` above)
+            with ZkJobRegistry() as registry:
+                registry.register(
+                    job_id=job_id,
+                    user_id=TEST_USER,
+                    api_version="1.0.0",
+                    specification=dict(
+                        process_graph=data,
+                        job_options=job_options,
+                    ),
+                    title="Fake Test Job",
+                    description="Fake job for the purpose of testing"
+                )
+                registry.set_status(job_id=job_id, user_id=TEST_USER, status=JOB_STATUS.FINISHED)
+
+                # Download
+                res = api.get(
+                    '/jobs/{j}/results'.format(j=job_id), headers=TEST_USER_AUTH_HEADER
+                ).assert_status_code(200).json
+                if api.api_version_compare.at_least("1.0.0"):
+                    assert "openEO_2017-11-21Z.tif" in res["assets"]
+                    download_url = res["assets"]["openEO_2017-11-21Z.tif"]["href"]
+                else:
+                    download_url = res["links"][0]["href"]
+
+                retrieve_url = api.client.get
+                if download_url.startswith("http://127.0.0.1:"):
+                    # pre-signed urls don't woark with flask retriever
+                    def retrieve_url_and_set_data(*args, **kwargs):
+                        result = requests.get(*args, **kwargs)
+                        setattr(result, "data", result.text.encode("utf-8"))
+                        return result
+                    retrieve_url = retrieve_url_and_set_data
+
+                if auth_header:
+                    res = retrieve_url(download_url, headers=TEST_USER_AUTH_HEADER)
+                else:
+                    res = retrieve_url(download_url)
+
+                assert res.status_code == expected_code
+                if 200 <= expected_code < 300:
+                    # For succesfull api requests check response data
+                    assert res.data == TIFF_DUMMY_DATA
 
     @mock.patch(
         "openeogeotrellis.configparams.ConfigParams.use_object_storage",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -845,7 +845,21 @@ class TestBatchJobs:
     )
     @pytest.mark.parametrize(
         "config_overrides,idp_enabled,auth_header,expected_code", [
-            # When using the new PresignedS3AssetUrls with required config in place we should never fail
+            # When using the new PresignedS3AssetUrls with ipd in place but not required config in place we should
+            # be on old behavior
+            [
+                {
+                    "asset_url": PresignedS3AssetUrls(),
+                    "s3_region_proxy_endpoints": {},  # Mimic no proxy configured => missing required config
+                }, True, False, 401
+            ],
+            [
+                {
+                    "asset_url": PresignedS3AssetUrls(),
+                    "s3_region_proxy_endpoints": {},  # Mimic no proxy configured => missing required config
+                }, True, True, 200
+            ],
+            # When using the new PresignedS3AssetUrls with ipd & required config in place we should never fail
             [
                 {
                     "asset_url": PresignedS3AssetUrls()


### PR DESCRIPTION
If the geopyspark-driver has config set to be able to issue IDP tokens and the STS endpoint as well as a new config s3_region_proxy_endpoints which has the S3 proxy endpoint per region then it will generate presigned S3 urls for assets as long as it knows about the asset buckets via a workspace.

This builds on top of https://github.com/Open-EO/openeo-python-driver/pull/387
The changes in conftest allows for easier overrides and thus as a workaround for https://github.com/Open-EO/openeo-python-driver/issues/265

This replaces #1119 