### PR TITLE
sts: strict timeouts

### DIFF
--- a/openeogeotrellis/integrations/s3proxy/exceptions.py
+++ b/openeogeotrellis/integrations/s3proxy/exceptions.py
@@ -1,14 +1,18 @@
 class ProxyException(RuntimeError):
-    ...
+    pass
 
 
 class S3ProxyDisabled(ProxyException):
-    ...
+    pass
 
 
 class S3ProxyUnsupportedBucketType(ProxyException):
-    ...
+    pass
 
 
 class DriverCannotIssueTokens(ProxyException):
-    ...
+    pass
+
+
+class CredentialsException(ProxyException):
+    pass


### PR DESCRIPTION
The boto3 defaults of 1 minute do not make sense for a local STS endpoint. One second is already long. All exceptions should be encapsulated as a proxy error which allows alternative handling by the caller.