### PR TITLE
workspaces: actually use region specific config

### DIFF
--- a/openeogeotrellis/integrations/s3/__init__.py
+++ b/openeogeotrellis/integrations/s3/__init__.py
@@ -1,2 +1,3 @@
 from openeogeotrellis.integrations.s3.bucket_details import BucketDetails, is_workspace_bucket
 from openeogeotrellis.integrations.s3.presigned_url import create_presigned_url
+from openeogeotrellis.integrations.s3.client import get_s3_client

--- a/openeogeotrellis/integrations/s3/client.py
+++ b/openeogeotrellis/integrations/s3/client.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+import boto3
+
+from typing import TYPE_CHECKING
+from openeogeotrellis.integrations.s3.endpoint import get_endpoint
+from openeogeotrellis.integrations.s3.credentials import get_credentials
+
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
+
+
+def get_s3_client(region_name: str) -> S3Client:
+    return boto3.client(
+        "s3", region_name=region_name, endpoint_url=get_endpoint(region_name), **get_credentials(region_name)
+    )

--- a/openeogeotrellis/integrations/s3/credentials.py
+++ b/openeogeotrellis/integrations/s3/credentials.py
@@ -1,0 +1,53 @@
+import logging
+import os
+from typing import TypedDict, Optional
+
+
+from openeogeotrellis.integrations.s3.providers import get_s3_provider
+
+_log = logging.getLogger(__name__)
+
+
+class Boto3CredentialsTypeDef(TypedDict):
+    aws_access_key_id: str
+    aws_secret_access_key: str
+
+
+def get_credentials(region_name: str) -> Boto3CredentialsTypeDef:
+    """
+    Credential resolving should always go from most specific to least specific. So let's say we are checking region
+    waw3-1 of the cloudferro cloud we must check in order:
+    - CF_WAW3_1_ACCESS_KEY_ID && CF_WAW3_1_SECRET_ACCESS_KEY
+    - CF_ACCESS_KEY_ID && CF_SECRET_ACCESS_KEY
+    - SWIFT_ACCESS_KEY_ID && SWIFT_SECRET_ACCESS_KEY  # for backwards compatibility
+    - AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY
+    """
+    provider_name = get_s3_provider(region_name)
+
+    for prefix in [f"{provider_name}_{region_name}", f"{provider_name}", "SWIFT", "AWS"]:
+        credential_candidate = get_credential_for_prefix(prefix)
+        if credential_candidate is not None:
+            return credential_candidate
+    raise EnvironmentError(f"Cannot get credentials for {region_name}")
+
+
+def _sanitize_env_name(env_name: str) -> str:
+    return env_name.upper().replace("-", "_")
+
+
+def get_credential_for_prefix(prefix: str) -> Optional[Boto3CredentialsTypeDef]:
+    """
+    When getting credentials from the environment they should have both parts to be valid (access_key_id and secret_key)
+    """
+    access_key_id = os.environ.get(_sanitize_env_name(f"{prefix}_ACCESS_KEY_ID"))
+    secret_key = os.environ.get(_sanitize_env_name(f"{prefix}_SECRET_ACCESS_KEY"))
+    if access_key_id is None and secret_key is None:
+        return None
+    elif access_key_id is None or secret_key is None:
+        # Credentials must come in pairs so having only 1 part smells like environment misconfiguration
+        _log.warning(f"Likely invalid backend config for managing credentials for {prefix}")
+        return None
+    return {
+        "aws_access_key_id": access_key_id,
+        "aws_secret_access_key": secret_key,
+    }

--- a/openeogeotrellis/integrations/s3/endpoint.py
+++ b/openeogeotrellis/integrations/s3/endpoint.py
@@ -1,0 +1,46 @@
+import os
+from typing import Callable
+
+from openeogeotrellis.integrations.s3.providers import CF, OTC, get_s3_provider, EODATA
+
+
+def get_cf_endpoint(region_name: str) -> str:
+    return f"https://s3.{region_name}.cloudferro.com"
+
+
+def get_otc_endpoint(region_name: str) -> str:
+    return f"https://obs.{region_name}.otc.t-systems.com"
+
+
+def get_eodata_endpoint(_: str) -> str:
+    """
+    EODATA is a special case because it is often accessed via a private path which differs per environment.
+    As such the details need to be extracted from the execution environment. We recommend a specific environment
+    variable but fallback to legacy values
+    """
+    try:
+        return os.environ["EODATA_S3_ENDPOINT"]
+    except KeyError:
+        try:
+            endpoint_without_protocol = os.environ["AWS_S3_ENDPOINT"]
+            if os.environ["AWS_HTTPS"] == "NO":
+                return f"http://{endpoint_without_protocol}"
+            else:
+                return f"https://{endpoint_without_protocol}"
+        except KeyError as ke:
+            raise EnvironmentError("No valid config for eodata access.") from ke
+
+
+def get_endpoint_builder(provider_name: str) -> Callable[[str], str]:
+    if provider_name == CF:
+        return get_cf_endpoint
+    elif provider_name == OTC:
+        return get_otc_endpoint
+    elif provider_name == EODATA:
+        return get_eodata_endpoint
+    raise NotImplementedError(f"Unsupported provider {provider_name}")
+
+
+def get_endpoint(region_name) -> str:
+    provider = get_s3_provider(region_name)
+    return get_endpoint_builder(provider)(region_name)

--- a/openeogeotrellis/integrations/s3/providers.py
+++ b/openeogeotrellis/integrations/s3/providers.py
@@ -1,0 +1,18 @@
+"""
+This file ties regions to cloud providers.
+
+"""
+
+CF = "cf"  # CloudFerro
+OTC = "otc"  # Open Telekom cloud
+EODATA = "eodata"  # eodata is considered a separate cloud provider stack
+
+
+def get_s3_provider(region_name: str) -> str:
+    if region_name in ["waw3-1", "waw3-2", "waw4-1"]:
+        return CF
+    elif region_name in ["eu-nl", "eu-de"]:
+        return OTC
+    elif region_name in ["eodata"]:
+        return EODATA
+    raise NotImplementedError(f"Unsupported region {region_name}")

--- a/openeogeotrellis/utils.py
+++ b/openeogeotrellis/utils.py
@@ -259,7 +259,8 @@ def set_max_memory(max_total_memory_in_bytes: int):
 
 
 def s3_client():
-    # TODO: move this to openeogeotrellis.integrations.s3?
+    # TODO: replace all use cases with openeogeotrellis.integrations.s3.get_s3_client because all remaining calls
+    # imply a region dependency
     import boto3
 
     # TODO: Get these credentials/secrets from VITO TAP vault instead of os.environ

--- a/openeogeotrellis/workspace/object_storage_workspace.py
+++ b/openeogeotrellis/workspace/object_storage_workspace.py
@@ -12,7 +12,7 @@ from openeo_driver.workspace import Workspace, _merge_collection_metadata
 from pystac import STACObject, Collection, CatalogType, Item, Asset
 from pystac.layout import HrefLayoutStrategy, CustomLayoutStrategy
 
-from openeogeotrellis.utils import s3_client
+from openeogeotrellis.integrations.s3 import get_s3_client
 from .custom_stac_io import CustomStacIO
 
 _log = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ class ObjectStorageWorkspace(Workspace):
         config = TransferConfig(multipart_threshold=self.MULTIPART_THRESHOLD_IN_MB * MB)
 
         key = f"{subdirectory}/{file_relative}"
-        s3_client().upload_file(str(file), self.bucket, key, Config=config)
+        get_s3_client(self.region).upload_file(str(file), self.bucket, key, Config=config)
 
         if remove_original:
             file.unlink()
@@ -58,7 +58,7 @@ class ObjectStorageWorkspace(Workspace):
 
         target_key = f"{merge}/{file_relative}"
 
-        s3 = s3_client()
+        s3 = get_s3_client(self.region)
         s3.copy_object(CopySource={"Bucket": source_bucket, "Key": source_key}, Bucket=self.bucket, Key=target_key)
         if remove_original:
             s3.delete_object(Bucket=source_bucket, Key=source_key)
@@ -153,7 +153,7 @@ class ObjectStorageWorkspace(Workspace):
         workspace_uri = f"s3://{self.bucket}/{target_key}"
 
         if source_uri_parts.scheme in ["", "file"]:
-            s3_client().upload_file(str(source_path), self.bucket, target_key)
+            get_s3_client(self.region).upload_file(str(source_path), self.bucket, target_key)
 
             if remove_original:
                 source_path.unlink()
@@ -163,7 +163,8 @@ class ObjectStorageWorkspace(Workspace):
             source_bucket = source_uri_parts.netloc
             source_key = str(source_path).lstrip("/")
 
-            s3 = s3_client()
+            # TODO: Move away from copy_object because unreliable for cross region
+            s3 = get_s3_client(self.region)
             s3.copy_object(CopySource={"Bucket": source_bucket, "Key": source_key}, Bucket=self.bucket, Key=target_key)
             if remove_original:
                 s3.delete_object(Bucket=source_bucket, Key=source_key)

--- a/tests/integrations/test_s3.py
+++ b/tests/integrations/test_s3.py
@@ -1,0 +1,167 @@
+from openeogeotrellis.integrations.s3 import get_s3_client
+import pytest
+
+from openeogeotrellis.integrations.s3.credentials import get_credentials
+
+
+eodata_test_endpoint = "eodata.oeo.test"
+
+
+@pytest.fixture
+def historic_eodata_endpoint_env_config(monkeypatch):
+    monkeypatch.setenv("AWS_S3_ENDPOINT", eodata_test_endpoint)
+    monkeypatch.setenv("AWS_HTTPS", "NO")
+
+
+@pytest.fixture
+def new_eodata_endpoint_env_config(monkeypatch):
+    monkeypatch.setenv("EODATA_S3_ENDPOINT", f"https://{eodata_test_endpoint}")
+
+
+@pytest.fixture
+def swift_credentials(monkeypatch):
+    monkeypatch.setenv("SWIFT_ACCESS_KEY_ID", "swiftkey")
+    monkeypatch.setenv("SWIFT_SECRET_ACCESS_KEY", "swiftsecret")
+
+
+@pytest.mark.parametrize(
+    "region_name,expected_endpoint",
+    [
+        pytest.param(
+            "waw3-1",
+            "https://s3.waw3-1.cloudferro.com",
+        ),
+        pytest.param(
+            "waw3-2",
+            "https://s3.waw3-2.cloudferro.com",
+        ),
+        pytest.param(
+            "waw4-1",
+            "https://s3.waw4-1.cloudferro.com",
+        ),
+        pytest.param("eu-nl", "https://obs.eu-nl.otc.t-systems.com"),
+        pytest.param("eu-de", "https://obs.eu-de.otc.t-systems.com"),
+        pytest.param("eodata", f"http://{eodata_test_endpoint}"),
+    ],
+)
+def test_s3_client_has_expected_endpoint_and_region(
+    historic_eodata_endpoint_env_config, swift_credentials, region_name: str, expected_endpoint: str
+):
+    c = get_s3_client(region_name)
+    assert region_name == c.meta.region_name
+    assert expected_endpoint == c.meta.endpoint_url
+
+
+@pytest.mark.parametrize(
+    "region_name,expected_endpoint",
+    [
+        pytest.param("eodata", f"https://{eodata_test_endpoint}"),
+    ],
+)
+def test_s3_client_prefered_eodata_config(
+    new_eodata_endpoint_env_config,
+    historic_eodata_endpoint_env_config,
+    swift_credentials,
+    region_name: str,
+    expected_endpoint: str,
+):
+    c = get_s3_client(region_name)
+    assert region_name == c.meta.region_name
+    assert expected_endpoint == c.meta.endpoint_url
+
+
+@pytest.mark.parametrize(
+    "region_name,env,exp_akid,exp_secret",
+    [
+        pytest.param(
+            "waw3-1",
+            {
+                "SWIFT_ACCESS_KEY_ID": "swiftkey",
+                "SWIFT_SECRET_ACCESS_KEY": "swiftsecret",
+                "AWS_ACCESS_KEY_ID": "awskey",
+                "AWS_SECRET_ACCESS_KEY": "awssecret",
+            },
+            "swiftkey",
+            "swiftsecret",
+            id="backwardsCompatibleSwiftFallbackButBeforeAWS",
+        ),
+        pytest.param(
+            "waw3-1",
+            {
+                "AWS_ACCESS_KEY_ID": "awskey",
+                "AWS_SECRET_ACCESS_KEY": "awssecret",
+            },
+            "awskey",
+            "awssecret",
+            id="backwardsCompatibleFallbackAWS",
+        ),
+        pytest.param(
+            "waw3-1",
+            {
+                "OTC_ACCESS_KEY_ID": "cfaccess",
+                "OTC_SECRET_ACCESS_KEY": "csecret",
+                "SWIFT_ACCESS_KEY_ID": "swiftkey",
+                "SWIFT_SECRET_ACCESS_KEY": "swiftsecret",
+                "AWS_ACCESS_KEY_ID": "awskey",
+                "AWS_SECRET_ACCESS_KEY": "awssecret",
+            },
+            "swiftkey",
+            "swiftsecret",
+            id="VendorSpecificCredentialsTakePrecedenceButIgnoredIfNotRightVendor",
+        ),
+        pytest.param(
+            "waw3-1",
+            {
+                "CF_ACCESS_KEY_ID": "cfaccess",
+                "CF_SECRET_ACCESS_KEY": "csecret",
+                "SWIFT_ACCESS_KEY_ID": "swiftkey",
+                "SWIFT_SECRET_ACCESS_KEY": "swiftsecret",
+                "AWS_ACCESS_KEY_ID": "awskey",
+                "AWS_SECRET_ACCESS_KEY": "awssecret",
+            },
+            "cfaccess",
+            "csecret",
+            id="VendorSpecificCredentialsTakePrecedenceIfMatch",
+        ),
+        pytest.param(
+            "waw3-1",
+            {
+                "CF_WAW3_1_ACCESS_KEY_ID": "cfaccesswaw31",
+                "CF_WAW3_1_SECRET_ACCESS_KEY": "csecretwaw31",
+                "CF_ACCESS_KEY_ID": "cfaccess",
+                "CF_SECRET_ACCESS_KEY": "csecret",
+                "SWIFT_ACCESS_KEY_ID": "swiftkey",
+                "SWIFT_SECRET_ACCESS_KEY": "swiftsecret",
+                "AWS_ACCESS_KEY_ID": "awskey",
+                "AWS_SECRET_ACCESS_KEY": "awssecret",
+            },
+            "cfaccesswaw31",
+            "csecretwaw31",
+            id="RegionSpecificCredentialsTakePrecedenceIfMatch",
+        ),
+        pytest.param(
+            "eodata",
+            {
+                "CF_WAW3_1_ACCESS_KEY_ID": "cfaccesswaw31",
+                "CF_WAW3_1_SECRET_ACCESS_KEY": "csecretwaw31",
+                "CF_ACCESS_KEY_ID": "cfaccess",
+                "CF_SECRET_ACCESS_KEY": "csecret",
+                "EODATA_ACCESS_KEY_ID": "eodataaccess",
+                "EODATA_SECRET_ACCESS_KEY": "eodataecret",
+                "SWIFT_ACCESS_KEY_ID": "swiftkey",
+                "SWIFT_SECRET_ACCESS_KEY": "swiftsecret",
+                "AWS_ACCESS_KEY_ID": "awskey",
+                "AWS_SECRET_ACCESS_KEY": "awssecret",
+            },
+            "eodataaccess",
+            "eodataecret",
+            id="EodataProviderConfigIsResolvable",
+        ),
+    ],
+)
+def test_s3_credentials_retrieval_from_env(monkeypatch, region_name: str, env: dict, exp_akid, exp_secret: str):
+    for env_var, env_val in env.items():
+        monkeypatch.setenv(env_var, env_val)
+    creds = get_credentials(region_name)
+    assert exp_akid == creds["aws_access_key_id"]
+    assert exp_secret == creds["aws_secret_access_key"]


### PR DESCRIPTION
Workspaces track a region but client config just takes environment variable which assume workspace is in the same region as the execution environment its object storage.

This change adds openeogeotrellis.integrations.s3.get_s3_client which takes a region and then configures the client as required.