### PR TITLE
Use UV compliant package version for geopyspark-openeo and enable uv venv building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,4 +32,5 @@ pythonPipeline {
     '/data/MTDA:/data/MTDA:ro'
   ]
   enable_caching = true
+  enable_uv = true
 }

--- a/openeogeotrellis/config/config.py
+++ b/openeogeotrellis/config/config.py
@@ -28,7 +28,7 @@ def _default_capabilities_deploy_metadata() -> dict:
             "openeo",
             "openeo_driver",
             "openeo-geopyspark",
-            "geopyspark",
+            "geopyspark-openeo",
         ],
         jar_paths=find_geotrellis_jars(),
     )

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'pyspark>=2.3.1,<2.4.0; python_version<"3.8"',
         # TODO #1220 the +openeo suffix to point to this fork of geopyspark seems to cause trouble in some newer build contexts
         #      move to a more explicit forked project, e.g. `geopyspark-openeo`?
-        'geopyspark==0.4.9+openeo',
+        'geopyspark_openeo==0.4.3.post1',
         # rasterio is an undeclared but required dependency for geopyspark
         # (see https://github.com/locationtech-labs/geopyspark/issues/683 https://github.com/locationtech-labs/geopyspark/pull/706)
         'rasterio~=1.2.0; python_version<"3.9"',

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,6 @@ setup(
         "openeo_driver>=0.135.0a2.dev",
         'pyspark==3.5.3; python_version>="3.8"',
         'pyspark>=2.3.1,<2.4.0; python_version<"3.8"',
-        # TODO #1220 the +openeo suffix to point to this fork of geopyspark seems to cause trouble in some newer build contexts
-        #      move to a more explicit forked project, e.g. `geopyspark-openeo`?
         'geopyspark_openeo==0.4.3.post1',
         # rasterio is an undeclared but required dependency for geopyspark
         # (see https://github.com/locationtech-labs/geopyspark/issues/683 https://github.com/locationtech-labs/geopyspark/pull/706)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -100,7 +100,7 @@ class TestCapabilities:
                 "openeo": semver_alike,
                 "openeo_driver": semver_alike,
                 "openeo-geopyspark": semver_alike,
-                "geopyspark": semver_alike,
+                "geopyspark-openeo": semver_alike,
                 "geotrellis-extensions": semver_alike,
             },
         }
@@ -108,7 +108,7 @@ class TestCapabilities:
             "openeo": semver_alike,
             "openeo_driver": semver_alike,
             "openeo-geopyspark": semver_alike,
-            "geopyspark": semver_alike,
+            "geopyspark-openeo": semver_alike,
             "geotrellis-extensions": semver_alike,
         }
 


### PR DESCRIPTION
Fixes #1220.