### PR TITLE
feature: request proxy url that also allows head requests

### DIFF
--- a/openeogeotrellis/integrations/s3proxy/asset_urls.py
+++ b/openeogeotrellis/integrations/s3proxy/asset_urls.py
@@ -39,7 +39,12 @@ class PresignedS3AssetUrls(AssetUrl):
     def _get_presigned_url_against_proxy(self, bucket: str, key: str, job_id: str, user_id: str) -> str:
         s3_client = get_proxy_s3_client_for_job(bucket, job_id, user_id)
         url = create_presigned_url(
-            s3_client, bucket_name=bucket, object_name=key, expiration=self._expiration, default=None
+            s3_client,
+            bucket_name=bucket,
+            object_name=key,
+            expiration=self._expiration,
+            default=None,
+            parameters={"X-Proxy-Head-As-Get": "true"},
         )
         if url is None:
             raise ValueError(f"Could not create a presigned url for s3://{bucket}/{key} job_id={job_id} user={user_id}")

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     tests_require=tests_require,
     install_requires=[
         "openeo>=0.42.0.dev",
-        "openeo_driver>=0.135.0a3.dev",
+        "openeo_driver>=0.135.0a4.dev",
         'pyspark==3.5.3; python_version>="3.8"',
         'pyspark>=2.3.1,<2.4.0; python_version<"3.8"',
         'geopyspark_openeo==0.4.3.post1',

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1075,12 +1075,14 @@ class TestBatchJobs:
 
                 retrieve_url = api.client.get
                 if download_url.startswith("http://127.0.0.1:"):
-                    # pre-signed urls don't woark with flask retriever
+                    # pre-signed urls don't work with flask retriever
                     def retrieve_url_and_set_data(*args, **kwargs):
                         result = requests.get(*args, **kwargs)
                         setattr(result, "data", result.text.encode("utf-8"))
                         return result
                     retrieve_url = retrieve_url_and_set_data
+                    # Proxy should allow Head requests which requires extra header.
+                    assert "X-Proxy-Head-As-Get=true" in download_url
 
                 if auth_header:
                     res = retrieve_url(download_url, headers=TEST_USER_AUTH_HEADER)


### PR DESCRIPTION
Make sure that when geotrellis driver generates presigned URLs that they also are usable with HTTP head requests.