### PR TITLE
doc: job-options memory options

### DIFF
--- a/openeogeotrellis/job_options.py
+++ b/openeogeotrellis/job_options.py
@@ -57,7 +57,7 @@ class JobOptions:
             "description": "Setting to specifically limit the memory used by python on a worker. "
             "Leaving this setting empty will enforce the default value of the backend. None will be zero bytes. "
             "Typical processes that use python-memory are UDF's, sar_backscatter or Sentinel 3 data loading. "
-            "This memory not a reservation so it can act as executor_memory_overhead but it is enforced as a limit."
+            "This memory is not a reservation so it can act as executor_memory_overhead but it is enforced as a limit."
             "Memory allocation problems with one of aforementioned processes likely warrant an increase of this value."
         })
     executor_cores: int = field(

--- a/openeogeotrellis/job_options.py
+++ b/openeogeotrellis/job_options.py
@@ -57,7 +57,7 @@ class JobOptions:
             "description": "Setting to specifically limit the memory used by python on a worker. "
             "Leaving this setting empty will enforce the default value of the backend. None will be zero bytes. "
             "Typical processes that use python-memory are UDF's, sar_backscatter or Sentinel 3 data loading. "
-            "This memory is not a reservation so it can act as executor_memory_overhead but it is enforced as a limit."
+            "This memory is not a reservation so it can act as executor_memory_overhead but it is enforced as a limit. "
             "Memory allocation problems with one of aforementioned processes likely warrant an increase of this value."
         })
     executor_cores: int = field(

--- a/openeogeotrellis/job_options.py
+++ b/openeogeotrellis/job_options.py
@@ -55,7 +55,7 @@ class JobOptions:
         default=get_backend_config().default_python_memory,
         metadata={
             "description": "Setting to specifically limit the memory used by python on a worker. "
-            "Leaving this setting empty will enforce the default value of the backend. None will be zero bytes."
+            "Leaving this setting empty will enforce the default value of the backend. None will be zero bytes. "
             "Typical processes that use python-memory are UDF's, sar_backscatter or Sentinel 3 data loading. "
             "This memory not a reservation so it can act as executor_memory_overhead but it is enforced as a limit."
             "Memory allocation problems with one of aforementioned processes likely warrant an increase of this value."

--- a/openeogeotrellis/job_options.py
+++ b/openeogeotrellis/job_options.py
@@ -48,15 +48,17 @@ class JobOptions:
         default=get_backend_config().default_executor_memoryOverhead,
         metadata={
             "name": "executor-memoryOverhead",
-            "description": "Memory allocated to the workers in addition to the JVM, for example, to run UDFs. "
-            "The total available memory of an executor is equal to executor-memory + executor-memoryOverhead [+ python-memory].",
+            "description": "Memory allocated to the workers in addition to the JVM. "
+            "The total available memory of an executor is equal to executor-memory + executor-memoryOverhead + python-memory.",
         })
     python_memory: str = field(
         default=get_backend_config().default_python_memory,
         metadata={
             "description": "Setting to specifically limit the memory used by python on a worker. "
+            "Leaving this setting empty will enforce the default value of the backend. None will be zero bytes."
             "Typical processes that use python-memory are UDF's, sar_backscatter or Sentinel 3 data loading. "
-            "Leaving this setting empty will allow Python to use almost all of the executor-memoryOverhead, but may lead to unclear error messages when the memory limit is reached."
+            "This memory not a reservation so it can act as executor_memory_overhead but it is enforced as a limit."
+            "Memory allocation problems with one of aforementioned processes likely warrant an increase of this value."
         })
     executor_cores: int = field(
         default=get_backend_config().default_executor_cores,

--- a/openeogeotrellis/job_options.py
+++ b/openeogeotrellis/job_options.py
@@ -49,16 +49,18 @@ class JobOptions:
         metadata={
             "name": "executor-memoryOverhead",
             "description": "Memory allocated to the workers in addition to the JVM. "
-            "The total available memory of an executor is equal to executor-memory + executor-memoryOverhead + python-memory.",
+            "The total available memory of an executor is equal to executor-memory + executor-memoryOverhead + python-memory. "
+            "Therefore this option allows to foresee additional memory for processes other than the JVM or the Python runtime.",
         })
     python_memory: str = field(
         default=get_backend_config().default_python_memory,
         metadata={
             "description": "Setting to specifically limit the memory used by python on a worker. "
             "Leaving this setting empty will enforce the default value of the backend. None will be zero bytes. "
-            "Typical processes that use python-memory are UDF's, sar_backscatter or Sentinel 3 data loading. "
-            "This memory is not a reservation so it can act as executor_memory_overhead but it is enforced as a limit. "
-            "Memory allocation problems with one of aforementioned processes likely warrant an increase of this value."
+            "The total available memory of an executor is equal to executor-memory + executor-memoryOverhead + python-memory. "
+            "Typical processes that use python-memory are UDF's, sar_backscatter or Sentinel 3 data loading "
+            "for these this python_memory limit should be used rather than executor_memory_overhead. "
+            "Memory allocation problems for one of the aforementioned processes likely warrant an increase of this value. "
         })
     executor_cores: int = field(
         default=get_backend_config().default_executor_cores,


### PR DESCRIPTION
Clarify the documentation on memory related job-options. If the backend has a default of None then [a limit of 0 bytes is set](https://github.com/Open-EO/openeo-geopyspark-driver/commit/18e512d84c594591a90b2a357becfdc5f00266aa#diff-f606c26975b555ceec5f9fd97aa22cb9372fdd3d508db2eb8ae248f3b559f2eeL134) rather then no enforcement.

Also clarify that it is purely a limit and not a reservation and avoid mentioning UDFs for memory overhead.