### PR TITLE
feat: expose compression method and predictor when writing GTiff files

### DIFF
--- a/scripts/jars.json
+++ b/scripts/jars.json
@@ -17,9 +17,9 @@
       "https://artifactory.vgt.vito.be/artifactory/libs-snapshot-public/org/openeo/openeo-logging/2.5.1_2.12-SNAPSHOT/openeo-logging-2.5.1_2.12-SNAPSHOT.jar"
     ],
     "spark35-scala213": [
-      "https://artifactory.vgt.vito.be/artifactory/libs-release-public/org/openeo/geotrellis-extensions/PR-562/geotrellis-extensions-PR-562.jar",
-      "https://artifactory.vgt.vito.be/artifactory/libs-release-public/org/openeo/geotrellis-dependencies/PR-562/geotrellis-dependencies-PR-562.jar",
-      "https://artifactory.vgt.vito.be/artifactory/libs-release-public/org/openeo/openeo-logging/PR-562/openeo-logging-PR-562.jar"
+      "https://artifactory.vgt.vito.be/artifactory/libs-snapshot-public/org/openeo/geotrellis-extensions/2.5.1_2.13-SNAPSHOT/geotrellis-extensions-2.5.1_2.13-SNAPSHOT.jar",
+      "https://artifactory.vgt.vito.be/artifactory/libs-snapshot-public/org/openeo/geotrellis-dependencies/2.5.1_2.13-SNAPSHOT/geotrellis-dependencies-2.5.1_2.13-SNAPSHOT.jar",
+      "https://artifactory.vgt.vito.be/artifactory/libs-snapshot-public/org/openeo/openeo-logging/2.5.1_2.13-SNAPSHOT/openeo-logging-2.5.1_2.13-SNAPSHOT.jar"
     ],
     "PR-549": [
       "https://artifactory.vgt.vito.be/artifactory/libs-release-public/org/openeo/geotrellis-extensions/PR-549/geotrellis-extensions-PR-549.jar",


### PR DESCRIPTION
# https://github.com/Open-EO/openeo-geopyspark-driver/issues/1234