### PR TITLE
Improvements/calrissian

### DIFF
--- a/openeogeotrellis/config/integrations/calrissian_config.py
+++ b/openeogeotrellis/config/integrations/calrissian_config.py
@@ -4,7 +4,7 @@ DEFAULT_NAMESPACE = "calrissian-demo-project"
 DEFAULT_INPUT_STAGING_IMAGE = "alpine:3"
 # TODO #1007 proper calrissian image? Official one doesn't work due to https://github.com/Duke-GCB/calrissian/issues/124#issuecomment-947008286
 DEFAULT_CALRISSIAN_IMAGE = "ghcr.io/duke-gcb/calrissian/calrissian:0.17.1"
-DEFAULT_SECURITY_CONTEXT = dict(run_as_user=1000, run_as_group=1000)
+DEFAULT_SECURITY_CONTEXT = dict(run_as_user=1000, fs_group=0, run_as_group=0)
 DEFAULT_CALRISSIAN_S3_BUCKET = "calrissian"
 DEFAULT_CALRISSIAN_BASE_ARGUMENTS = (
     "--debug",

--- a/openeogeotrellis/config/integrations/calrissian_config.py
+++ b/openeogeotrellis/config/integrations/calrissian_config.py
@@ -3,7 +3,7 @@ import attrs
 DEFAULT_NAMESPACE = "calrissian-demo-project"
 DEFAULT_INPUT_STAGING_IMAGE = "alpine:3"
 # TODO #1007 proper calrissian image? Official one doesn't work due to https://github.com/Duke-GCB/calrissian/issues/124#issuecomment-947008286
-DEFAULT_CALRISSIAN_IMAGE = "ghcr.io/duke-gcb/calrissian/calrissian:0.17.1"
+DEFAULT_CALRISSIAN_IMAGE = "ghcr.io/duke-gcb/calrissian/calrissian:0.18.1"
 DEFAULT_SECURITY_CONTEXT = dict(run_as_user=1000, fs_group=0, run_as_group=0)
 DEFAULT_CALRISSIAN_S3_BUCKET = "calrissian"
 DEFAULT_CALRISSIAN_BASE_ARGUMENTS = (

--- a/openeogeotrellis/integrations/calrissian.py
+++ b/openeogeotrellis/integrations/calrissian.py
@@ -167,7 +167,9 @@ class CalrissianJobLauncher:
             mount_path="/calrissian/output-data",
         )
 
-        self._security_context = kubernetes.client.V1SecurityContext(**(security_context or DEFAULT_SECURITY_CONTEXT))
+        self._security_context = kubernetes.client.V1PodSecurityContext(
+            **(security_context or DEFAULT_SECURITY_CONTEXT)
+        )
 
     @staticmethod
     def from_context() -> CalrissianJobLauncher:

--- a/openeogeotrellis/integrations/calrissian.py
+++ b/openeogeotrellis/integrations/calrissian.py
@@ -227,7 +227,7 @@ class CalrissianJobLauncher:
         container = kubernetes.client.V1Container(
             name=name,
             image=self._input_staging_image,
-            image_pull_policy="IfNotPresent",
+            image_pull_policy="Always",
             security_context=self._security_context,
             command=["/bin/sh"],
             args=["-c", f"set -euxo pipefail; echo '{cwl_serialized}' | base64 -d > {cwl_path}"],
@@ -330,7 +330,7 @@ class CalrissianJobLauncher:
         container = kubernetes.client.V1Container(
             name=name,
             image=self._calrissian_image,
-            image_pull_policy="IfNotPresent",
+            image_pull_policy="Always",
             security_context=self._security_context,
             command=["calrissian"],
             args=calrissian_arguments,

--- a/tests/integrations/test_calrissian.py
+++ b/tests/integrations/test_calrissian.py
@@ -73,7 +73,7 @@ class TestCalrissianJobLauncher:
                         {
                             "name": "r-1234-cal-inp-01234567",
                             "image": "alpine:3",
-                            "image_pull_policy": "IfNotPresent",
+                            "image_pull_policy": "Always",
                             "command": ["/bin/sh"],
                             "args": [
                                 "-c",
@@ -134,7 +134,7 @@ class TestCalrissianJobLauncher:
                         {
                             "name": "r-123-cal-cwl-01234567",
                             "image": DEFAULT_CALRISSIAN_IMAGE,
-                            "image_pull_policy": "IfNotPresent",
+                            "image_pull_policy": "Always",
                             "command": ["calrissian"],
                             "args": dirty_equals.Contains(
                                 "--tmp-outdir-prefix",


### PR DESCRIPTION
Calrissian changes to allow running with new container image:

- Use V1PodSecurityContext to specify fsgroup for calrissian pod
- change run_as_group to root (to make sure Python binary in Calrissian image is still usable even with user with id 1000)
- always pull the container.