### PR TITLE
size of the window in apply_neighborhood must consider overlap

### DIFF
--- a/openeogeotrellis/geopysparkdatacube.py
+++ b/openeogeotrellis/geopysparkdatacube.py
@@ -1228,8 +1228,8 @@ class GeopysparkDataCube(DriverDataCube):
                 process="apply_neighborhood",
                 reason=f"only 'px' is currently supported for spatial window size (got {size!r})",
             )
-        sizeX = int(size_dict[x.name]['value'])
-        sizeY = int(size_dict[y.name]['value'])
+        sizeX = int(size_dict[x.name]['value'] + (2*overlap_dict[x.name]['value']))
+        sizeY = int(size_dict[y.name]['value'] + (2*overlap_dict[y.name]['value']))
 
         overlap_x_dict = overlap_dict.get(x.name,{'value': 0, 'unit': 'px'})
         overlap_y_dict = overlap_dict.get(y.name,{'value': 0, 'unit': 'px'})


### PR DESCRIPTION
The real size of the moving window must be size + (2*overlap) following the documentation: 

"In the example below, the UDF will receive chunks of 128x128 pixels: 112 is the chunk size, while 2 times 8 pixels of overlap on each side of the chunk results in 128."
https://open-eo.github.io/openeo-python-client/udf.html