### PR TITLE
`load_stac`: add detection of proj metadata from asset "bands"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ without compromising stable operations.
 - Experimental support for dropping `derived_from` links on the STAC Collection level in favor of a link, to a dedicated document with input features, on the item level ([#1278](https://github.com/Open-EO/openeo-geopyspark-driver/issues/1278))
 - `sar_backscatter`: under specific circumstances, data was cropped during processing, leading to missing outputs ([#1403](https://github.com/Open-EO/openeo-geopyspark-driver/issues/1403))
 - Improve vector cube support in `export_workspace` ([#1404](https://github.com/Open-EO/openeo-geopyspark-driver/issues/1404))
+- `load_stac`: support detection of projection metadata from asset "bands" ([#1391](https://github.com/Open-EO/openeo-geopyspark-driver/issues/1391))
 
 
 ## 0.69.0


### PR DESCRIPTION
resolves  #1391

*but* this solution might actually be too much outside the standard STAC scope, see:
-  https://github.com/stac-extensions/projection/issues/25 