### PR TITLE
load_stac: add `asset_id_to_bands_map` feature flag to support copern…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ without compromising stable operations.
 - Remove `udf_python_dependencies_folder_path` from `PYTHONPATH` in batch jobs (k8s context) (eu-cdse/openeo-cdse-infra#842)
 - Check UDF code for managed UDF dependencies before doing (possibly) more expensive IO/S3 operations (eu-cdse/openeo-cdse-infra#842)
 - post-dry-run: initial support for global extent alignment with `load_stac` ([#1299](https://github.com/Open-EO/openeo-geopyspark-driver/issues/1299), [openeo-python-driver#406](https://github.com/Open-EO/openeo-python-driver/issues/406))
-
+- `load_stac`: added `asset_id_to_bands_map` feature flag in order to support collections that do not contain band name information (e.g. COPERNICUS_30 on CDSE).
 
 ## 0.69.0
 


### PR DESCRIPTION
…icus DEM collections

These collections do not contain band information in their STAC metadata so we need to map the asset_id to a list of band 
names.

The `_vito` field in layercatalog.json will look like this:
```
    "_vito": {
      "data_source": {
        "realign": false,
        "type": "stac",
        "url": "https://stac.dataspace.copernicus.eu/v1/collections/cop-dem-glo-90-dged-cog",
        "consider_as_singular_time_step": true,
        "provider:backend": "creodias",
        "load_stac_feature_flags": {
          "asset_id_to_bands_map": {
            "data": ["DEM"],
            "GeoTIFF": ["DEM"]
          }
        }
      }
    }
``` 


https://github.com/eu-cdse/openeo-cdse-infra/issues/808 
https://github.com/eu-cdse/openeo-cdse-infra/issues/809

