### PR TITLE
Fix: Masking before binning now handles band names with ":"

### DIFF
--- a/openeogeotrellis/collections/sentinel3.py
+++ b/openeogeotrellis/collections/sentinel3.py
@@ -494,15 +494,19 @@ def do_binning(
         "lon": (("y", "x"), source_coordinates[0, :]),
         "lat": (("y", "x"), source_coordinates[1, :]),
     }
+    band_names_parsed = []
 
     for band_name in band_names:
         logger.info(" Reprojecting %s" % band_name)
         base_name = band_name
         if ":" in band_name:
             base_name, band_name = band_name.split(":")
+
         in_file = creo_path /  (base_name + '.nc')
         if product_type == SYNERGY_PRODUCT_TYPE and not band_name.endswith("_flags"):
                 band_name = f"SDR_{band_name.split('_')[1]}"
+
+        band_names_parsed.append(band_name)
         band_data, band_settings = read_band(in_file, in_band=band_name, data_mask=data_mask)
 
         # We are rescaling before the binning in order to correctly handle fill values (not identifiable after binning)
@@ -515,9 +519,10 @@ def do_binning(
         attrs[band_name] = band_settings
 
     if flag_band is not None:
-        if flag_band not in band_names:
-            raise ValueError(f"Specified flag_band '{flag_band}', which was not found in specified bands '{band_names}'")
-        data_band_names = set(band_names) - {flag_band}
+        logger.info(f"Interpreting band '{flag_band}' as flag, with bitmask '{flag_bitmask}'")
+        if flag_band not in band_names_parsed:
+            raise ValueError(f"Specified flag_band '{flag_band}', which was not found in specified bands '{band_names_parsed}'")
+        data_band_names = set(band_names_parsed) - {flag_band}
 
         flags = data_vars.pop(flag_band)[1]
         if not np.issubdtype(flags.dtype, np.integer):

--- a/tests/data_collections/test_sentinel3.py
+++ b/tests/data_collections/test_sentinel3.py
@@ -181,7 +181,7 @@ def test_mask_before_binning(mock_read_band):
     value_to_be_masked = 5
     value_to_keep = 1
     fill_value = np.nan
-    mask_set = 0x01
+    mask_set = 4
 
     shape = (4, 5)
     out_shape = shape
@@ -198,7 +198,7 @@ def test_mask_before_binning(mock_read_band):
         data = None
         if in_band == "CLOUD_flags":
             data = mask_data
-        elif in_band == "SDR_04":
+        elif in_band == "SDR_Oa04":
             data = band_data
         else:
             raise ValueError(f"in_band '{in_band}' not recognized")
@@ -216,7 +216,7 @@ def test_mask_before_binning(mock_read_band):
         product_type=SYNERGY_PRODUCT_TYPE,
         final_grid_resolution=1.0,
         creo_path=Path("fake_path"),
-        band_names=["CLOUD_flags", "SDR_04"],
+        band_names=["flags:CLOUD_flags", "Syn_Oa04_reflectance"],
         source_coordinates=source_coordinates,
         target_coordinates=target_coordinates,
         data_mask=None,


### PR DESCRIPTION
PR #1458 contained a bug that made it impossible to specify a mask band.
Because the band names of the Synergy product type sometimes contain a colon, e.g. "flags:CLOUD_flags", if specifying the mask band as `CLOUD_flags` it was not found in the `band_names`.

However, because the band is finally looked up in the resulting Dataset object, where the prefix is already stripped, specifying the mask band as "flags:CLOUD_flags" also would not work.

This PR addresses this issue, the band name without the prefix should be used to specify the mask band.