### PR TITLE
Fix: masking before binning now considers that flag bands are converted to float

### DIFF
--- a/openeogeotrellis/collections/sentinel3.py
+++ b/openeogeotrellis/collections/sentinel3.py
@@ -524,14 +524,12 @@ def do_binning(
             raise ValueError(f"Specified flag_band '{flag_band}', which was not found in specified bands '{band_names_parsed}'")
         data_band_names = set(band_names_parsed) - {flag_band}
 
-        flags = data_vars.pop(flag_band)[1]
-        if not np.issubdtype(flags.dtype, np.integer):
-            raise ValueError(f"flag_band must be an integer band. Flag band '{flag_band}' has dtype '{flags.dtype}'")
-
+        flags = data_vars[flag_band][1]
         for band_name in data_band_names:
-            fill_value = attrs.get(band_name, {}).get('_FillValue', np.nan)
+            fill_value = np.nan
             band_dims, band_data = data_vars[band_name]
-            masked_band_data = xr.where((flags & flag_bitmask) > 0, fill_value, band_data)
+            band_dtype = attrs[band_name]["dtype"]
+            masked_band_data = xr.where(np.isnan(flags) | (flags.astype(band_dtype) & flag_bitmask) > 0, fill_value, band_data)
             data_vars[band_name] = (band_dims, masked_band_data)
 
     ds_in = xr.Dataset(

--- a/tests/data_collections/test_sentinel3.py
+++ b/tests/data_collections/test_sentinel3.py
@@ -98,6 +98,43 @@ def test_read_single_binned():
     arr = result[0][1].cells
     return
 
+def test_read_masked_binned():
+    tiles = [
+        {
+            "key":{
+                "col":10,
+                "row":10,
+                "instant":100,
+
+            },
+            #{"type":"Polygon","coordinates":[[[-180,73.130594],[-152.392,69.3935],[-165.135,59.9629],[-180,62.346828],[-180,73.130594]]]}
+            "key_extent":{
+                "xmin":-180.0,"xmax":-176.0,"ymin":60.0,"ymax":64.0,
+            },
+            "key_epsg":4326
+        }
+    ]
+    result = read_product(
+        (
+            Path(__file__).parent.parent
+            / "data/binary/Sentinel-3/S3A_SY_2_SYN____20250516T222406_20250516T222706_20250518T150818_0179_126_058_1800_PS1_O_NT_002.SEN3",
+            tiles,
+        ),
+        SYNERGY_PRODUCT_TYPE,
+        ["flags:CLOUD_flags", "Syn_Oa01_reflectance"],
+        tile_size=1024,
+        resolution=0.008928571428571,
+        reprojection_type=REPROJECTION_TYPE_BINNING,
+        binning_args={
+            KEY_SUPER_SAMPLING: 3,
+            KEY_FLAG_BAND: "CLOUD_flags",
+            KEY_FLAG_BITMASK: 0xff,
+        }
+    )
+
+    arr = result[0][1].cells
+
+
 def test_read_single_edge():
 
     tiles = [


### PR DESCRIPTION
Following up on PR #1458 .

This PR fixes an issue where the mask would not be applied correctly before binning, because the flag band is converted to float values before the mask can be applied.