### PR TITLE
feature: have correlation_id for created pods

### DIFF
--- a/openeogeotrellis/deploy/sparkapplication_template.yaml.j2
+++ b/openeogeotrellis/deploy/sparkapplication_template.yaml.j2
@@ -258,6 +258,7 @@ spec:
       name: {{ job_id_short }}-driver
       openeo-role: "batch-driver"
       job_id: {{ job_id_full }}
+      correlation_id: {{ job_id_full }}
       user_id: {{user_id}}
 {%- endblock %}
     volumeMounts:
@@ -399,6 +400,7 @@ spec:
       version: 3.2.0
       openeo-role: "executor"
       job_id: {{ job_id_full }}
+      correlation_id: {{ job_id_full }}
       user_id: {{user_id}}
 {%- endblock %}
     volumeMounts:


### PR DESCRIPTION
correlation_id is an id that specifies what triggered the resource creation. For batch jobs this is the job_id.

This change is to add the labels to the driver and executors of a batch job.