### PR TITLE
calrissian: specify container resources for all utility pods

### DIFF
--- a/openeogeotrellis/config/integrations/calrissian_config.py
+++ b/openeogeotrellis/config/integrations/calrissian_config.py
@@ -6,6 +6,10 @@ DEFAULT_NAMESPACE = "calrissian-demo-project"
 DEFAULT_INPUT_STAGING_IMAGE = "alpine:3"
 # TODO #1007 proper calrissian image? Official one doesn't work due to https://github.com/Duke-GCB/calrissian/issues/124#issuecomment-947008286
 DEFAULT_CALRISSIAN_IMAGE = "ghcr.io/duke-gcb/calrissian/calrissian:0.18.1"
+DEFAULT_CALRISSIAN_RUNNER_RESOURCE_REQUIREMENTS = dict(
+    limits={"memory": "256Mi"}, requests={"cpu": "1m", "memory": "256Mi"}
+)
+
 DEFAULT_SECURITY_CONTEXT = dict(run_as_user=1000, fs_group=0, run_as_group=0)
 DEFAULT_CALRISSIAN_S3_REGION = None
 DEFAULT_CALRISSIAN_S3_BUCKET = "calrissian"
@@ -56,3 +60,9 @@ class CalrissianConfig:
     s3_bucket: str = DEFAULT_CALRISSIAN_S3_BUCKET
 
     security_context: dict = attrs.Factory(DEFAULT_SECURITY_CONTEXT.copy)
+
+    """
+    The pod that runs the calrissian tool is the runner of the CWL workflow and requires its own resources to drive
+    the resources that actually perform the work which are specified . Ideally a default
+    """
+    runner_resource_requirements: dict = attrs.Factory(DEFAULT_CALRISSIAN_RUNNER_RESOURCE_REQUIREMENTS.copy)

--- a/openeogeotrellis/integrations/calrissian.py
+++ b/openeogeotrellis/integrations/calrissian.py
@@ -29,6 +29,7 @@ from openeogeotrellis.config.integrations.calrissian_config import (
     DEFAULT_CALRISSIAN_S3_REGION,
     DEFAULT_INPUT_STAGING_IMAGE,
     DEFAULT_SECURITY_CONTEXT,
+    DEFAULT_CALRISSIAN_RUNNER_RESOURCE_REQUIREMENTS,
     CalrissianConfig,
 )
 from openeogeotrellis.integrations.kubernetes import ensure_kubernetes_config
@@ -223,6 +224,12 @@ class CalrissianJobLauncher:
     Helper class to launch a Calrissian job on Kubernetes.
     """
 
+    # Hard code given the small but predictable requirements
+    _HARD_CODED_STAGE_JOB_RESOURCES = {
+        "limits": {"memory": "10Mi"},
+        "requests": {"cpu": "1m", "memory": "10Mi"},
+    }
+
     def __init__(
         self,
         *,
@@ -236,6 +243,7 @@ class CalrissianJobLauncher:
         security_context: Optional[dict] = None,
         backoff_limit: int = 1,
         calrissian_base_arguments: Sequence[str] = DEFAULT_CALRISSIAN_BASE_ARGUMENTS,
+        runner_resource_requirements: Optional[dict] = None,
     ):
         self._namespace = namespace
         self._name_base = name_base or generate_unique_id(prefix="cal")[:20]
@@ -267,6 +275,10 @@ class CalrissianJobLauncher:
 
         self._security_context = kubernetes.client.V1PodSecurityContext(
             **(security_context or DEFAULT_SECURITY_CONTEXT)
+        )
+
+        self._runner_resource_requirements = kubernetes.client.V1ResourceRequirements(
+            **(runner_resource_requirements or DEFAULT_CALRISSIAN_RUNNER_RESOURCE_REQUIREMENTS)
         )
 
     @staticmethod
@@ -353,6 +365,7 @@ class CalrissianJobLauncher:
             security_context=config.security_context,
             calrissian_image=config.calrissian_image,
             input_staging_image=config.input_staging_image,
+            runner_resource_requirements=config.runner_resource_requirements,
         )
 
     def _build_unique_name(self, infix: str) -> str:
@@ -395,6 +408,7 @@ class CalrissianJobLauncher:
                     name=self._volume_input.name, mount_path=self._volume_input.mount_path, read_only=False
                 )
             ],
+            resources=kubernetes.client.V1ResourceRequirements(**self._HARD_CODED_STAGE_JOB_RESOURCES),
         )
         manifest = kubernetes.client.V1Job(
             metadata=kubernetes.client.V1ObjectMeta(
@@ -520,6 +534,7 @@ class CalrissianJobLauncher:
             ]
             + [self._calrissian_launch_config.get_volume_mount()],
             env=container_env_vars,
+            resources=self._runner_resource_requirements,
         )
         manifest = kubernetes.client.V1Job(
             metadata=kubernetes.client.V1ObjectMeta(


### PR DESCRIPTION
Make sure calrissian utility pods will have resource specifications.

For pods that stage inputs the memory footprint is small and the pods are very short-lived so it is OK to hard-code a value deemed safe for any pratical case. (Since input is base64 passed it has anyway length constraints).

For the pod running calrissian itself the config is not as clear cut. We go for 256MB which should be a comfortable default but we take if from config such that it can be experimented with and backend can tune it for their supported workflow use cases. 