### PR TITLE
Add output dir to asset

### DIFF
--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -2762,7 +2762,8 @@ class GpsBatchJobs(backend.BatchJobs):
         job_dir = self.get_job_output_dir(job_id=job_id)
         for item in results_metadata["items"]:
             for asset_key, asset in item["assets"].items():
-                asset["output_dir"] = str(job_dir)
+                if not ConfigParams().use_object_storage:
+                    asset["output_dir"] = str(job_dir)
         return {item["id"]: item for item in results_metadata["items"]}
 
 


### PR DESCRIPTION
Addition for [#1393](https://github.com/Open-EO/openeo-geopyspark-driver/issues/1393) , because asset keys are no longer filename