### PR TITLE
Add test showcasing shapely.equals already uses a tolerance. 

### DIFF
--- a/tests/test_load_stac.py
+++ b/tests/test_load_stac.py
@@ -2482,6 +2482,10 @@ class TestItemDeduplicator:
                 {"type": "Polygon", "coordinates": [[[4, 50], [5, 50], [5, 51], [4, 51], [4, 50]]]},
                 ["item1", "item3"],
             ),
+            (
+                {"type": "Polygon", "coordinates": [[[4, 50], [5, 50], [5, 51], [4, 51], [4, 50.0001]]]},
+                ["item1", "item3"],
+            ),
             (None, ["item1", "item2", "item3"]),
             (
                 {"type": "Polygon", "coordinates": [[[8, 40], [9, 40], [9, 41], [8, 41], [8, 40]]]},


### PR DESCRIPTION
https://github.com/Open-EO/openeo-geopyspark-driver/issues/1495
@codex review