### PR TITLE
PropertyFilter: add properties_prefix option with quickfix heuristic …

### DIFF
--- a/openeogeotrellis/load_stac.py
+++ b/openeogeotrellis/load_stac.py
@@ -867,11 +867,18 @@ def construct_item_collection(
             band_names = stac_metadata_parser.bands_from_stac_collection(collection=collection).band_names()
             logger.info(f"construct_item_collection: STAC API Collection {collection.id!r}, {band_names=}, {netcdf_with_time_dimension=}")
 
-            property_filter = PropertyFilter(properties=property_filter_pg_map, env=env)
+            # TODO: this prefix mode heuristic need massive improvement, but it's just a quickfix for now
+            properties_prefix = "" if "dataspace.copernicus.eu" in url else "properties."
+            property_filter = PropertyFilter(
+                properties=property_filter_pg_map, env=env, properties_prefix=properties_prefix
+            )
             if property_filter_adaptations := feature_flags.get("property_filter_adaptations"):
                 logger.debug(f"AdaptingPropertyFilter with {property_filter_adaptations=}")
                 property_filter = AdaptingPropertyFilter(
-                    properties=property_filter_pg_map, env=env, adaptations=property_filter_adaptations
+                    properties=property_filter_pg_map,
+                    env=env,
+                    adaptations=property_filter_adaptations,
+                    properties_prefix=properties_prefix,
                 )
 
             with TimingLogger(title=f"ItemCollection.from_stac_api from {url=}", logger=logger.info):
@@ -2090,9 +2097,16 @@ class PropertyFilter:
 
     # TODO: move this utility to a more generic location for better reuse
 
-    def __init__(self, properties: PropertyFilterPGMap, *, env: Optional[EvalEnv] = None):
+    def __init__(
+        self,
+        properties: PropertyFilterPGMap,
+        *,
+        env: Optional[EvalEnv] = None,
+        properties_prefix: str = "properties.",
+    ):
         self._properties = properties
         self._env = env or EvalEnv()
+        self._properties_prefix = properties_prefix
 
     def _iter_literal_matches(self) -> Iterator[Tuple[str, str, Any]]:
         """Helper to produce tuples of property-name, operator and value"""
@@ -2175,7 +2189,7 @@ class PropertyFilter:
                 value = repr(tuple(value))
             else:
                 value = repr(value)
-            filters.append(f'"{property_name}" {operator} {value}')
+            filters.append(f'"{self._properties_prefix}{property_name}" {operator} {value}')
         return " and ".join(filters)
 
     def _to_cql2_operator(self, operator: str):
@@ -2202,7 +2216,7 @@ class PropertyFilter:
         filters = [
             {
                 "op": self._to_cql2_operator(operator),
-                "args": [{"property": f"{property_name}"}, value],
+                "args": [{"property": f"{self._properties_prefix}{property_name}"}, value],
             }
             for property_name, operator, value in self._iter_literal_matches()
             if operator != "like"
@@ -2246,8 +2260,9 @@ class AdaptingPropertyFilter(PropertyFilter):
         *,
         env: Optional[EvalEnv] = None,
         adaptations: Dict[str, Union[dict, str]],
+        properties_prefix: str = "properties.",
     ):
-        super().__init__(properties=properties, env=env)
+        super().__init__(properties=properties, env=env, properties_prefix=properties_prefix)
         self._adaptations = adaptations
 
     def _iter_literal_matches(self) -> Iterator[Tuple[str, str, Any]]:


### PR DESCRIPTION
for #1584

CDSE STAC suddenly changed how properties should be specified in CQL2 filters ("properties." prefix should be dropped)

unit tests still assume original behavior, so keeping "properties." as the default for now Ad-hoc opt-out based on provided STAC url to cover CDSE STAC