### PR TITLE
Estimate STAC raster cube size (before querying STAC API)

### DIFF
--- a/openeogeotrellis/geopysparkcubemetadata.py
+++ b/openeogeotrellis/geopysparkcubemetadata.py
@@ -196,13 +196,14 @@ class GeopysparkCubeMetadata(CollectionMetadata):
     def get_layer_crs(self) -> str:
         # TODO: improve naming: in openEO there are "collections", "bands" and "cubes",
         #       it's unclear what "layer" means here: it seems to refer to the source "collection",
-        #       while were here in the context of "cube" metadata
+        #       while we're here in the context of "cube" metadata
         #       (which already might have a different CRS than the source collection)
         crs = self.get("cube:dimensions", "x", "reference_system", default="EPSG:4326")
         if isinstance(crs, int):
             crs = "EPSG:%s" % str(crs)
         elif isinstance(crs, dict):
             if crs.get("name") == "AUTO 42001 (Universal Transverse Mercator)":
+                # TODO: this is an ad-hoc, non-standard CRS code. Isn't this going to cause trouble elsewhere?
                 crs = "Auto42001"
         return crs
 
@@ -232,6 +233,7 @@ class GeopysparkCubeMetadata(CollectionMetadata):
         band_to_gsd = {}
         for band_metadata in bands_metadata:
             band_name = band_metadata.get("name")
+            # TODO: "resolution" is not an official STAC property, where does this come from?
             band_gsd = band_metadata.get("gsd") or band_metadata.get("resolution")
             if not band_gsd and "openeo:gsd" in band_metadata:
                 unit = band_metadata["openeo:gsd"]["unit"]
@@ -246,6 +248,7 @@ class GeopysparkCubeMetadata(CollectionMetadata):
         if len(band_to_gsd) > 0:
             return band_to_gsd
 
+        # TODO: "item_assets" > "classification" looks overly use-case specific. What is this about?
         gsd_layer_wide = clean_number_pair(self.get("item_assets", "classification", "gsd", default=None))
         if gsd_layer_wide:
             return gsd_layer_wide
@@ -255,6 +258,7 @@ class GeopysparkCubeMetadata(CollectionMetadata):
             # step could be expressed in LatLon or layer native crs.
             # Only when the layer native CRS is LatLon, we can trust it
             # https://github.com/stac-extensions/datacube#dimension-object
+            # TODO: revisit these assumptions: step is per definition in crs specified under "reference_system"
 
             bboxes = self.get("extent", "spatial", "bbox")
             if bboxes and len(bboxes) > 0:

--- a/openeogeotrellis/layercatalog.py
+++ b/openeogeotrellis/layercatalog.py
@@ -1418,7 +1418,7 @@ def is_layer_too_large(
         native_crs: str,
         threshold_pixels: int = LARGE_LAYER_THRESHOLD_IN_PIXELS,
         sync_job: bool = False,
-):
+) -> Union[str, None]:
     """
     Estimates the number of pixels that will be required to load this layer
     and returns True if it exceeds the threshold.
@@ -1435,6 +1435,9 @@ def is_layer_too_large(
     :return: A message if the layer exceeds the threshold in pixels. None otherwise.
              Also returns the estimated number of pixels and the threshold.
     """
+    # TODO: this function needs unit tests
+    # TODO: confusing separation between extra_validation_load_collection and is_layer_too_large:
+    #       former handles band and temporal dimension, while latter handles spatial dimension. Why?
     geometries = load_params.aggregate_spatial_geometries
     spatial_extent = load_params.spatial_extent
     srs = spatial_extent.get("crs", 'EPSG:4326')
@@ -1444,6 +1447,7 @@ def is_layer_too_large(
         if srs["name"] == 'AUTO 42001 (Universal Transverse Mercator)':
             srs = 'Auto42001'
 
+    # TODO: avoid in-place modification of load_params.spatial_extent
     spatial_extent["crs"] = srs
     if not health_check_extent(spatial_extent):
         return f"Unsupported spatial extent: {spatial_extent}"
@@ -1473,11 +1477,13 @@ def is_layer_too_large(
     if srs != target_crs:
         spatial_extent = reproject_bounding_box(spatial_extent, from_crs=srs, to_crs=target_crs)
 
+    # TODO: this does not work properly accross antimeridian
     bbox_width = abs(spatial_extent["east"] - spatial_extent["west"])
     bbox_height = abs(spatial_extent["north"] - spatial_extent["south"])
 
     pixels_width = bbox_width / cell_width
     pixels_height = bbox_height / cell_height
+    # TODO: avoid hardcoding 20000 threshold here
     if sync_job and (pixels_width > 20000 or pixels_height > 20000) and not geometries:
         return f"Requested spatial extent is too large for a sync job {pixels_width:.0f}x{pixels_height:.0f} pixels. Max size: (20000x20000)."
 

--- a/openeogeotrellis/load_stac.py
+++ b/openeogeotrellis/load_stac.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import collections
 import datetime
 import datetime as dt
@@ -54,7 +56,14 @@ from openeogeotrellis.util.logging import TrackingIter
 from openeogeotrellis.util.datetime import DateTimeLikeOrNone, to_datetime_utc_unless_none
 from openeogeotrellis.util.geometry import GridSnapper
 from openeogeotrellis.util.projection import is_utm_epsg_code
-from openeogeotrellis.utils import get_jvm, map_optional, normalize_temporal_extent, to_projected_polygons, unzip
+from openeogeotrellis.utils import (
+    get_jvm,
+    map_optional,
+    normalize_temporal_extent,
+    to_projected_polygons,
+    unzip,
+    parse_approximate_isoduration,
+)
 
 if TYPE_CHECKING:
     from openeogeotrellis.geopysparkdatacube import GeopysparkDataCube
@@ -923,6 +932,9 @@ def construct_item_collection(
                 metadata=collection.to_dict(include_self_link=False, transform_hrefs=False)
             )
 
+            # TODO: estimate number of pixels
+            _StacRasterCubeSizeEstimator().estimate_cube_size(collection, spatiotemporal_extent=spatiotemporal_extent)
+
             band_names = stac_metadata_parser.bands_from_stac_collection(collection=collection).band_names()
             logger.info(f"construct_item_collection: STAC API Collection {collection.id!r}, {band_names=}, {netcdf_with_time_dimension=}")
 
@@ -1105,6 +1117,25 @@ class _TemporalExtent:
         start, end = interval
         return self.intersects(start_datetime=start, end_datetime=end)
 
+    def intersection(self, other: _TemporalExtent) -> Union[_TemporalExtent, None]:
+        """
+        Intersection of this extent with another
+        (or None when intersection is empty)
+        """
+        from_date = (
+            max(self.from_date, other.from_date)
+            if self.from_date and other.from_date
+            else self.from_date or other.from_date
+        )
+        to_date = min(self.to_date, other.to_date) if self.to_date and other.to_date else self.to_date or other.to_date
+
+        if from_date and to_date and from_date > to_date:
+            # No intersection, return sentinel for empty extent
+            # TODO: dedicated sentinel value (with some methods) for empty extent?
+            return None
+
+        return _TemporalExtent(from_date=from_date, to_date=to_date)
+
 
 class _SpatialExtent:
     """
@@ -1136,7 +1167,7 @@ class _SpatialExtent:
             return self._key() == other._key()
         return NotImplemented
 
-    def as_bbox(self, crs: Optional[str] = None) -> Union[BoundingBox, None]:
+    def as_bbox(self, crs: Union[str, int, None] = None) -> Union[BoundingBox, None]:
         bbox = self._bbox
         if bbox and crs:
             bbox = bbox.reproject(crs)
@@ -2517,3 +2548,138 @@ class _ResolutionTracker:
             finest_res = None
 
         return epsgs, finest_res
+
+
+class _StacRasterCubeSizeEstimator:
+    """
+    Utility to estimate the size of a raster data cube based on STAC collection metadata.
+    """
+
+    # TODO: move this to more general utilty module
+
+    def estimate_cube_size(
+        self,
+        collection: pystac.Collection,
+        *,
+        spatiotemporal_extent: _SpatioTemporalExtent,
+        # TODO: arg for band set or at least band count?
+    ) -> int:
+        # TODO: move to integrations.stac or another utility?
+        ...
+        # TODO: estimate band count
+        # TODO: estimate spatial pixel count (from bbox and resolution info)
+
+        temporal_size = self.estimate_temporal_dimension_size(
+            stac_obj=collection, temporal_extent=spatiotemporal_extent.temporal_extent
+        )
+        spatial_size = self.estimate_spatial_dimension_size(
+            stac_obj=collection, spatial_extent=spatiotemporal_extent.spatial_extent
+        )
+        band_size = 1  # TODO
+
+        return temporal_size * spatial_size[0] * spatial_size[1] * band_size
+
+    def estimate_temporal_dimension_size(
+        self, stac_obj: pystac.STACObject, *, temporal_extent: Optional[_TemporalExtent] = None
+    ) -> int:
+        """
+        Estimate the size of the temporal dimension (number of temporal labels or observations),
+        based on available metadata
+
+        :param temporal_extent: user requested temporal extent
+        """
+        if not temporal_extent:
+            temporal_extent = _TemporalExtent(None, None)
+        if isinstance(stac_obj, pystac.Item):
+            # TODO: this might be too simple
+            return 1
+        elif isinstance(stac_obj, pystac.Collection):
+            estimated_extent = _TemporalExtent(*stac_obj.extent.temporal.intervals[0])
+            if temporal_extent:
+                estimated_extent = estimated_extent.intersection(temporal_extent)
+            if not estimated_extent:
+                # Empty temporal extent would be size 0, but use 1 to be a bit more conservative
+                return 1
+
+            from_date = estimated_extent.from_date or datetime.datetime(2000, 1, 1)
+            to_date = estimated_extent.to_date or datetime.datetime.now(tz=datetime.timezone.utc)
+            temporal_dim = self._get_temporal_dimension(stac_obj) or {}
+            temporal_step = parse_approximate_isoduration(temporal_dim.get("step", "P1D"))
+            count = max(1, int((to_date - from_date).total_seconds() / temporal_step.total_seconds()))
+            return count
+        else:
+            raise ValueError(stac_obj)
+
+    def _get_temporal_dimension(self, stac_obj: pystac.STACObject) -> Union[dict, None]:
+        # TODO: instead of DIY parsing: leverage pystac built-in cube extension support once we can drop python3.8
+        if isinstance(stac_obj, pystac.Collection):
+            cube_dimensions = stac_obj.extra_fields.get("cube:dimensions", {})
+            temporal_dims = [d for d in cube_dimensions.values() if d.get("type") == "temporal"]
+            if temporal_dims:
+                return temporal_dims[0]
+        else:
+            # TODO
+            raise ValueError(stac_obj)
+
+    def estimate_spatial_dimension_size(
+        self, stac_obj: pystac.STACObject, *, spatial_extent: Optional[_SpatialExtent] = None
+    ) -> Tuple[int, int]:
+        if isinstance(stac_obj, pystac.Collection):
+            stac_extent = BoundingBox.from_wsen_tuple(stac_obj.extent.spatial.bboxes[0], crs=4326)
+        elif isinstance(stac_obj, pystac.Item) and stac_obj.bbox:
+            stac_extent = BoundingBox.from_wsen_tuple(stac_obj.bbox, crs=4326)
+        else:
+            # assume "whole world" as fallback
+            stac_extent = BoundingBox(west=-180, south=-90, east=180, north=90, crs=4326)
+
+        estimated_extent: BoundingBox = stac_extent
+        if spatial_extent:
+            estimated_extent = estimated_extent.intersection(spatial_extent.as_bbox(crs=4326))
+
+        # Determine estimated pixel size (aka cell size) from GSD metadata
+        # TODO: working with LonLat and GSD in meter is quite rough.
+        #       Is there collection-level metadata (without need to traverse items), that allows more precise calculation?
+        gsd_in_meter = self._get_spatial_gsd(stac_obj)
+
+        # TODO: fix antimeridian handling
+        width_lon = estimated_extent.east - estimated_extent.west
+        heigh_lat = estimated_extent.north - estimated_extent.south
+        # Back of envelope conversion from degrees to meter
+        if estimated_extent.south <= 0 < estimated_extent.north:
+            cos_lat = 1
+        else:
+            cos_lat = max(
+                math.cos(math.radians(estimated_extent.south)),
+                math.cos(math.radians(estimated_extent.north)),
+            )
+        width_meter = 40e6 * cos_lat * width_lon / 360.0
+        height_meter = 40e6 * heigh_lat / 360.0
+
+        size_x = int(max(1, width_meter / gsd_in_meter))
+        size_y = int(max(1, height_meter / gsd_in_meter))
+
+        return size_x, size_y
+
+    def _get_spatial_gsd(self, stac_obj: pystac.STACObject, fallback: float = 10) -> float:
+        """Estimate (finest) GSD (in meters) from metadata"""
+
+        def get_gsds_from_assets(assets: dict) -> Iterator[float]:
+            yield from (a["gsd"] for a in assets.values() if "gsd" in a)
+
+        def get_gsds_from_bands(bands: List[dict]) -> Iterator[float]:
+            yield from (b["gsd"] for b in bands if "gsd" in b)
+
+        def get_gsds(obj) -> Iterator[float]:
+            if isinstance(obj, pystac.Collection):
+                yield from obj.summaries.get_list("gsd") or []
+                if bands := obj.extra_fields.get("bands"):
+                    yield from get_gsds_from_bands(bands)
+                if assets := obj.extra_fields.get("item_assets"):
+                    yield from get_gsds_from_assets(assets)
+            elif isinstance(obj, pystac.Item):
+                if "gsd" in obj.properties:
+                    yield obj.properties["gsd"]
+                yield from get_gsds_from_assets(obj.assets)
+
+        gsds = set(get_gsds(stac_obj)) or {fallback}
+        return min(gsds)

--- a/openeogeotrellis/utils.py
+++ b/openeogeotrellis/utils.py
@@ -614,6 +614,7 @@ def calculate_rough_area(geoms: Iterable[BaseGeometry]):
         if hasattr(geom, "geoms"):
             total_area += calculate_rough_area(geom.geoms)
         else:
+            # TODO: this will go wrong around the antimeridian
             total_area += (geom.bounds[2] - geom.bounds[0]) * (geom.bounds[3] - geom.bounds[1])
     return total_area
 
@@ -698,9 +699,11 @@ def reproject_cellsize(
 
 
 def health_check_extent(extent):
+    # TODO: needs unit tests
     crs = extent.get("crs", "EPSG:4326")
     is_utm = crs == "Auto42001" or crs.startswith("EPSG:326")
 
+    # TODO: this logic is wrong: bounding boxes in EPSG:4326 across antimeridian will have west > east
     if extent["west"] > extent["east"] or extent["south"] > extent["north"]:
         logger.warning(f"health_check_extent extent with surface<0: {extent}")
         return False
@@ -739,7 +742,7 @@ def health_check_extent(extent):
     return True
 
 
-def parse_approximate_isoduration(s):
+def parse_approximate_isoduration(s) -> datetime.timedelta:
     """
     Parse the ISO8601 duration as years,months,weeks,days, hours,minutes,seconds.
     Approximate, because it does not care about leap years, months with different number of days, etc.

--- a/tests/test_load_stac.py
+++ b/tests/test_load_stac.py
@@ -51,6 +51,7 @@ from openeogeotrellis.load_stac import (
     _ResolutionTracker,
     STAC_API_PER_PAGE_LIMIT_DEFAULT,
     STAC_API_RETRY_TOTAL,
+    _StacRasterCubeSizeEstimator,
 )
 from openeogeotrellis.testing import DummyStacApiServer, gps_config_overrides
 from openeogeotrellis.util.geometry import bbox_to_geojson
@@ -1367,6 +1368,35 @@ class TestTemporalExtent:
     def test_from_load_param_extent(self, given, expected):
         extent = _TemporalExtent.from_load_param_extent(given)
         assert extent.as_tuple() == expected
+
+    @pytest.mark.parametrize(
+        ["first", "second", "expected"],
+        [
+            # All unbounded
+            ((None, None), (None, None), (None, None)),
+            # (partially) bounded x unbounded
+            (("2026-01-02", "2026-02-03"), (None, None), ("2026-01-02", "2026-02-03")),
+            ((None, "2026-02-03"), (None, None), (None, "2026-02-03")),
+            (("2026-01-02", None), (None, None), ("2026-01-02", None)),
+            # partially bounded x partially bounded
+            ((None, "2026-02-03"), (None, "2026-01-01"), (None, "2026-01-01")),
+            (("2026-02-03", None), ("2026-01-01", None), ("2026-02-03", None)),
+            ((None, "2026-02-03"), ("2026-01-01", None), ("2026-01-01", "2026-02-03")),
+            (("2026-02-03", None), (None, "2026-01-01"), None),
+            # bounded x bounded
+            (("2026-02-01", "2026-02-20"), ("2026-01-01", "2026-01-10"), None),
+            (("2026-02-01", "2026-02-20"), ("2026-01-01", "2026-02-10"), ("2026-02-01", "2026-02-10")),
+            (("2026-02-01", "2026-02-20"), ("2026-02-08", "2026-02-16"), ("2026-02-08", "2026-02-16")),
+            (("2026-02-01", "2026-02-20"), ("2026-02-10", "2026-03-01"), ("2026-02-10", "2026-02-20")),
+            (("2026-02-01", "2026-02-20"), ("2026-03-01", "2026-03-30"), None),
+        ],
+    )
+    def test_intersection(self, first, second, expected):
+        first = _TemporalExtent(*first)
+        second = _TemporalExtent(*second)
+        expected = _TemporalExtent(*expected) if expected else expected
+        assert first.intersection(second) == expected
+        assert second.intersection(first) == expected
 
 
 class TestSpatialExtent:
@@ -3868,4 +3898,83 @@ class TestResolutionTracker:
                 32631,
             },
             (10, 10),
+        )
+
+
+class TestStacRasterCubeSizeEstimator:
+    def test_estimate_temporal_dimension_size_item(self):
+        item = pystac.Item.from_dict(StacDummyBuilder.item())
+        assert _StacRasterCubeSizeEstimator().estimate_temporal_dimension_size(item) == 1
+
+    @pytest.mark.parametrize(
+        ["collection_temporal_extent", "cube_dimensions_t", "user_temporal_extent", "expected"],
+        [
+            (
+                # Only temporal extent in collection, no user-defined one
+                ["2026-01-01", "2026-01-31"],
+                {},
+                None,
+                30,
+            ),
+            (
+                # User-defined temporal extent
+                ["2020-01-01", None],
+                {},
+                ["2026-02-02", "2026-02-10"],
+                8,
+            ),
+            (
+                # Step defined in cube:dimensions
+                ["2020-01-01", None],
+                {"type": "temporal", "extent": ["2026-01-01", None], "step": "P10D"},
+                ["2026-01-01", "2026-02-20"],
+                5,
+            ),
+            (
+                # Intersection between collection and user-defined extent
+                ["2026-01-01", None],
+                {"type": "temporal", "extent": ["2026-01-01", None]},
+                ["2025-12-15", "2026-01-15"],
+                14,
+            ),
+        ],
+    )
+    def test_estimate_temporal_dimension_size_collection(
+        self, collection_temporal_extent, cube_dimensions_t, user_temporal_extent, expected
+    ):
+        extent = {
+            "spatial": {"bbox": [[3, 4, 5, 6]]},
+            "temporal": {"interval": [collection_temporal_extent]},
+        }
+        if cube_dimensions_t:
+            cube_dimensions = {"t": cube_dimensions_t}
+        else:
+            cube_dimensions = None
+        collection = pystac.Collection.from_dict(
+            StacDummyBuilder.collection(extent=extent, cube_dimensions=cube_dimensions)
+        )
+
+        actual = _StacRasterCubeSizeEstimator().estimate_temporal_dimension_size(
+            collection,
+            temporal_extent=_TemporalExtent(*user_temporal_extent) if user_temporal_extent else None,
+        )
+        assert actual == expected
+
+    def test_estimate_spatial_dimension_size_item_no_bbox(self):
+        item = pystac.Item.from_dict(StacDummyBuilder.item())
+        assert _StacRasterCubeSizeEstimator().estimate_spatial_dimension_size(item) == (
+            # Whole world at 10m assumption: 40 Mm x 20 Mm -> 4M x 2M pixels
+            pytest.approx(4e6, abs=1e3),
+            pytest.approx(2e6, abs=1e3),
+        )
+
+    def test_estimate_spatial_dimension_size_item_with_bbox(self):
+        bbox = BoundingBox(3, 51, 4, 52, crs=4326)
+        gsd = 60
+        item = pystac.Item.from_dict(
+            StacDummyBuilder.item(bbox=bbox.as_wsen_tuple(), geometry=bbox.as_geometry(), properties={"gsd": gsd})
+        )
+        assert _StacRasterCubeSizeEstimator().estimate_spatial_dimension_size(item) == (
+            pytest.approx(7000, rel=0.1),
+            pytest.approx(11, abs=0.1e6),
         )


### PR DESCRIPTION
work in progress PR that introduces `_StacRasterCubeSizeEstimator` utility to estimate size of a `load_stac` raster cube without/before iterating through multiple items from STAC collection or STAC API response

for #1591