### PR TITLE
adapt tests to changes in openeo-python-client's OIDC auth

### DIFF
--- a/tests/test_api_result.py
+++ b/tests/test_api_result.py
@@ -4886,7 +4886,7 @@ class TestEtlApiReporting:
                 "grant_type": ["client_credentials"],
                 "scope": ["openid"],
             }
-            return {"access_token": self._ETL_API_ACCESS_TOKEN}
+            return {"access_token": self._ETL_API_ACCESS_TOKEN, "token_type": "Bearer"}
 
         requests_mock.post("https://oidc.test/token", json=post_token)
 

--- a/tests/test_stac_api_workspace.py
+++ b/tests/test_stac_api_workspace.py
@@ -339,7 +339,7 @@ def test_vito_stac_api_workspace_helper(tmp_path, requests_mock, mock_s3_bucket,
     )
     get_access_token_mock = requests_mock.post(
         f"{oidc_issuer}/protocol/openid-connect/token",
-        json={"access_token": "4cc3ss_t0k3n"},
+        json={"access_token": "4cc3ss_t0k3n", "token_type": "Bearer"},
     )
 
     # mock STAC API


### PR DESCRIPTION
KeyError: 'token_type'