### PR TITLE
Add Process query_stac

### DIFF
--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -829,15 +829,17 @@ Example usage:
         temporal_extent: Tuple[Optional[str], Optional[str]],
         _env: EvalEnv
     ) -> Dict:
-        return self._query_stac_cached(url=url, spatial_extent=spatial_extent, temporal_extent=temporal_extent)
+        return self._query_stac_cached(url=url, spatial_extent=BadlyHashable(spatial_extent), temporal_extent=temporal_extent)
 
     @lru_cache(maxsize=20)
     def _query_stac_cached(
         self,
         url: str,
-        spatial_extent: Union[Dict, BoundingBox, None],
+        spatial_extent: Union[BadlyHashable, BoundingBox, None],
         temporal_extent: Tuple[Optional[str], Optional[str]],
     ) -> Dict:
+        if isinstance(spatial_extent, BadlyHashable):
+            spatial_extent = spatial_extent.target
         item_collection = query_stac.item_collection_from_stac_query(
             url=url,
             spatial_extent=spatial_extent,

--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -80,7 +80,7 @@ import numpy as np
 import openeogeotrellis
 import openeogeotrellis._backend.post_dry_run
 from openeo_driver.views import OPENEO_API_VERSION_DEFAULT
-from openeogeotrellis import sentinel_hub, load_stac, datacube_parameters
+from openeogeotrellis import sentinel_hub, load_stac, datacube_parameters, query_stac
 from openeogeotrellis.config import get_backend_config
 from openeogeotrellis.config.s3_config import S3Config
 from openeogeotrellis.configparams import ConfigParams
@@ -821,6 +821,29 @@ Example usage:
 
     def load_stac(self, url: str, load_params: LoadParameters, env: EvalEnv) -> GeopysparkDataCube:
         return self._load_stac_cached(url=url, load_params=load_params, env=WhiteListEvalEnv(env, WHITELIST))
+
+    def query_stac(
+        self,
+        url: str,
+        spatial_extent: Union[Dict, BoundingBox, None],
+        temporal_extent: Tuple[Optional[str], Optional[str]],
+        _env: EvalEnv
+    ) -> Dict:
+        return self._query_stac_cached(url=url, spatial_extent=spatial_extent, temporal_extent=temporal_extent)
+
+    @lru_cache(maxsize=20)
+    def _query_stac_cached(
+        self,
+        url: str,
+        spatial_extent: Union[Dict, BoundingBox, None],
+        temporal_extent: Tuple[Optional[str], Optional[str]],
+    ) -> Dict:
+        item_collection = query_stac.item_collection_from_stac_query(
+            url=url,
+            spatial_extent=spatial_extent,
+            temporal_extent=temporal_extent,
+        )
+        return item_collection.to_dict()
 
     @lru_cache(maxsize=20)
     def _load_stac_cached(self, url: str, *, load_params: LoadParameters, env: EvalEnv) -> GeopysparkDataCube:

--- a/openeogeotrellis/query_stac.py
+++ b/openeogeotrellis/query_stac.py
@@ -1,0 +1,35 @@
+import logging
+from typing import Dict, Optional, Union, Tuple
+from openeo_driver.util.geometry import BoundingBox
+from openeogeotrellis.load_stac import _spatiotemporal_extent_from_load_params, construct_item_collection
+
+import pystac
+
+logger = logging.getLogger(__name__)
+
+def item_collection_from_stac_query(
+        url: str,
+        spatial_extent: Union[Dict, BoundingBox, None],
+        temporal_extent: Tuple[Optional[str], Optional[str]],
+) -> pystac.ItemCollection:
+    """
+    Construct pystac ItemCollection from given load_stac URL.
+    Note that this, function returns `pystac's ItemCollection`_ type,
+    unlike :func:`openeogeotrellis.load_stac.construct_item_collection`, which returns the local implementation
+    :func:`openeogeotrellis.load_stac.ItemCollection` serving a similar purpose.
+    :func:`openeogeotrellis.load_stac.construct_item_collection` which is used internally by this function.
+
+    .. _pystac ItemCollection: https://pystac.readthedocs.io/en/latest/api/pystac.html#pystac.ItemCollection
+    """
+    spatiotemporal_extent = _spatiotemporal_extent_from_load_params(
+        spatial_extent=spatial_extent,
+        temporal_extent=temporal_extent,
+    )
+    property_filter_pg_map = None
+    item_collection, *_tail = construct_item_collection(
+        url=url,
+        spatiotemporal_extent=spatiotemporal_extent,
+        property_filter_pg_map=property_filter_pg_map,
+    )
+    logger.info(f"Query to '{url}' with spatial_extent '{spatial_extent}' and temporal_extent '{temporal_extent}'")
+    return pystac.ItemCollection(item_collection.items)

--- a/tests/test_query_stac.py
+++ b/tests/test_query_stac.py
@@ -3,10 +3,35 @@ import pytest
 from contextlib import nullcontext
 from .test_load_stac import _mock_stac_api
 
-def test_item_collection_response():
-    pass
+def test_non_empty_response(requests_mock, test_data):
+    stac_api_root_url = "https://stac.test"
+    stac_collection_url = f"{stac_api_root_url}/collections/collection"
 
-def test_empty_response(requests_mock, expectation=nullcontext()):
+    stac_item = test_data.load_json(
+        filename="stac/recursive-stac-example/sub-folder/openEO_2023-06-04Z.tif.json",
+    )
+
+    _mock_stac_api(
+        requests_mock,
+        stac_api_root_url,
+        stac_collection_url,
+        feature_collection={
+            "type": "FeatureCollection",
+            "features": [stac_item],
+        },
+    )
+
+    query_response = query_stac.item_collection_from_stac_query(
+        url=stac_collection_url,
+        spatial_extent={"west": 4.0, "south": 50.0, "east": 6.0, "north": 52.0},
+        temporal_extent=("2023-06-04", "2022-06-05"),
+    )
+
+    assert len(query_response) == 1
+    assert "openEO_2023-06-04Z.tif" in  query_response.to_dict().get("features")[0]["assets"]
+
+
+def test_empty_collection(requests_mock):
     stac_api_root_url = "https://stac.test"
     stac_collection_url = f"{stac_api_root_url}/collections/collection"
 
@@ -20,12 +45,11 @@ def test_empty_response(requests_mock, expectation=nullcontext()):
         },
     )
 
-    with expectation:
-        # TODO make an actual query
-        query_response = query_stac.item_collection_from_stac_query(
-            url=stac_collection_url,
-            spatial_extent={"west": 0.0, "south": 50.0, "east": 1.0, "north": 51.0},
-            temporal_extent=("2022-01-01", "2022-01-02"),
-        )
+    query_response = query_stac.item_collection_from_stac_query(
+        url=stac_collection_url,
+        spatial_extent={"west": 0.0, "south": 50.0, "east": 1.0, "north": 51.0},
+        temporal_extent=("2022-01-01", "2022-01-02"),
+    )
 
-    print("Done")
+    assert len(query_response) == 0
+    assert query_response.to_dict().get("features") == []

--- a/tests/test_query_stac.py
+++ b/tests/test_query_stac.py
@@ -1,0 +1,31 @@
+from openeogeotrellis import query_stac
+import pytest
+from contextlib import nullcontext
+from .test_load_stac import _mock_stac_api
+
+def test_item_collection_response():
+    pass
+
+def test_empty_response(requests_mock, expectation=nullcontext()):
+    stac_api_root_url = "https://stac.test"
+    stac_collection_url = f"{stac_api_root_url}/collections/collection"
+
+    _mock_stac_api(
+        requests_mock,
+        stac_api_root_url,
+        stac_collection_url,
+        feature_collection={
+            "type": "FeatureCollection",
+            "features": [],
+        },
+    )
+
+    with expectation:
+        # TODO make an actual query
+        query_response = query_stac.item_collection_from_stac_query(
+            url=stac_collection_url,
+            spatial_extent={"west": 0.0, "south": 50.0, "east": 1.0, "north": 51.0},
+            temporal_extent=("2022-01-01", "2022-01-02"),
+        )
+
+    print("Done")


### PR DESCRIPTION
Adds a new process "query_stac" which is a reduced and simplified version of "load_stac" which skips the "load" part of load_stac -> the items returned by the catalog query are not loaded into a data cube but instead provided as-is.

This is especially useful for processes that bypass the OpenEO data model and work on EO products directly, An example are processes based on [OGC Best Practice Earth Observation Application Packages](https://docs.ogc.org/bp/20-089r1.html).

This PR is made in the context of integrating the [FORCE EO Toolbox](https://force-eo.readthedocs.io/en/latest/) into the openeo-geopyspark-driver, in the context of ESA's [APEx](https://apex.esa.int/) project. The implementation serves this purpose first, FORCE needs to access EO products in in their raw format. However, the process was deemed general enough to be integrated as a general process.

The first implementation is quite limited in its functionality. A more featureful version should be developed together and share an implementation with `load_stac`, as the `query_stac` process provides essentially a part of the work that `load_stac` does. This version does not support all features (e.g. property filters) that `load_stac` supports. Some of these features may be added in time.

I am happy to receive any feedback on this PR, including choice of name for the process and placement in the repository.

@jdries @EmileSonneveld @martin-boettcher 

The corresponding PR to openeo-python-driver is https://github.com/Open-EO/openeo-python-driver/pull/480