### PR TITLE
fix job_tracker status update #1675

### DIFF
--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -2507,9 +2507,9 @@ class GpsBatchJobs(backend.BatchJobs):
 
         if "results_metadata_uri" in job_dict:
             results_metadata = self._load_results_metadata_from_file(job_id, job_dict["results_metadata_uri"])  # TODO: expose a getter?
-            if results_metadata:
+            if results_metadata and (registry_usage := job_dict.get("usage") is not None):
                 # Some fields in results_metadata_uri can be outdated. Update those directly from the job registry.
-                results_metadata["usage"] = job_dict.get("usage", results_metadata.get("usage"))
+                results_metadata["usage"] = registry_usage
 
         if not results_metadata and "results_metadata" in job_dict:
             logger.debug("Loading results metadata from job registry", extra={"job_id": job_id})


### PR DESCRIPTION
I think this was a regression introduced in 30379d5be4beb4d17cebc428e41b51c27904b887, where it is apparently possible to set `results_metadata["usage"]` to `None`; this fails further on.