### PR TITLE
fix: consistency in naming

### DIFF
--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -2010,7 +2010,7 @@ class GpsBatchJobs(backend.BatchJobs):
             if executor_corerequest == "NONE":
                 executor_corerequest = str(int(int(options.executor_cores) / 2 * 1000)) + "m"
 
-            driver_corerequest = options.driver_corerequest
+            driver_corerequest = options.driver_request_cores
             if driver_corerequest == "NONE":
                 driver_corerequest = str(int(options.driver_cores)  * 800) + "m"
 

--- a/openeogeotrellis/job_options.py
+++ b/openeogeotrellis/job_options.py
@@ -367,7 +367,7 @@ class K8SOptions(JobOptions):
             "public": False
         })
 
-    driver_corerequest: str = field(
+    driver_request_cores: str = field(
         default="NONE",
         metadata={
             "description": "CPU request for the driver, expressed as 'milli-cpus', for instance '500m' for 0.5 of 1 cpu unit. Allows partial CPU allocation for the driver.",

--- a/tests/test_job_options.py
+++ b/tests/test_job_options.py
@@ -126,7 +126,7 @@ def test_list_options_k8s():
     options = K8SOptions.list_options(public_only=False)
     assert_listing_shared_options(options)
     assert any(option["name"] == "executor-request-cores" for option in options)
-    assert any(option["name"] == "driver-corerequest" for option in options)
+    assert any(option["name"] == "driver-request-cores" for option in options)
 
 
 


### PR DESCRIPTION
The not yet public `driver_corerequest` is naming-wise inconsistent with the `executor_request_cores`. This PR alligns them while this option is not yet advertised.