### PR TITLE
Ignore dummy STAC.

### DIFF
--- a/openeogeotrellis/_backend/post_dry_run.py
+++ b/openeogeotrellis/_backend/post_dry_run.py
@@ -277,6 +277,8 @@ def _extract_spatial_extent_from_constraint_load_collection(
 def _extract_spatial_extent_from_constraint_load_stac(
     stac_url: str, *, constraint: dict, feature_flags: Optional[dict] = None
 ) -> Union[None, AlignedExtentResult]:
+    if stac_url == "dummy":
+        return None
     spatial_extent_from_pg = constraint.get("spatial_extent") or constraint.get("weak_spatial_extent")
 
     extent_orig: Union[BoundingBox, None] = BoundingBox.from_dict_or_none(spatial_extent_from_pg, default_crs=4326)

--- a/openeogeotrellis/_backend/post_dry_run.py
+++ b/openeogeotrellis/_backend/post_dry_run.py
@@ -16,7 +16,7 @@ from openeo_driver.errors import CollectionNotFoundException
 from openeo_driver.util.geometry import BoundingBox, epsg_code_or_none
 from openeo_driver.util.utm import is_auto_utm_crs, is_utm_crs
 from openeo_driver.utils import EvalEnv
-from openeogeotrellis.constants import EVAL_ENV_KEY
+from openeogeotrellis.constants import DUMMY_STAC_URL, EVAL_ENV_KEY
 
 import openeogeotrellis.load_stac
 from openeogeotrellis.util.geometry import BoundingBoxMerger
@@ -277,7 +277,7 @@ def _extract_spatial_extent_from_constraint_load_collection(
 def _extract_spatial_extent_from_constraint_load_stac(
     stac_url: str, *, constraint: dict, feature_flags: Optional[dict] = None
 ) -> Union[None, AlignedExtentResult]:
-    if stac_url == "dummy":
+    if stac_url == DUMMY_STAC_URL:
         return None
     spatial_extent_from_pg = constraint.get("spatial_extent") or constraint.get("weak_spatial_extent")
 

--- a/openeogeotrellis/backend.py
+++ b/openeogeotrellis/backend.py
@@ -86,7 +86,7 @@ from openeogeotrellis import sentinel_hub, load_stac, datacube_parameters, query
 from openeogeotrellis.config import get_backend_config
 from openeogeotrellis.config.s3_config import S3Config
 from openeogeotrellis.configparams import ConfigParams
-from openeogeotrellis.constants import JOB_OPTION_LOG_LEVEL
+from openeogeotrellis.constants import DUMMY_STAC_URL, JOB_OPTION_LOG_LEVEL
 from openeogeotrellis.geopysparkcubemetadata import Band
 from openeogeotrellis.geopysparkdatacube import GeopysparkCubeMetadata, GeopysparkDataCube
 from openeogeotrellis.integrations.credit_check import ExecutionDetails
@@ -1004,12 +1004,11 @@ Example usage:
             CwLSource.from_any(cwl),
         )
 
-        load_stac_dummy_url = "dummy"
         dry_run_tracer: DryRunDataTracer = env.get(ENV_DRY_RUN_TRACER)
         if dry_run_tracer:
             # TODO: use something else than `dry_run_tracer.load_stac`
             #       to avoid risk on conflict with "regular" load_stac code flows?
-            return dry_run_tracer.load_stac(url=load_stac_dummy_url, arguments={})
+            return dry_run_tracer.load_stac(url=DUMMY_STAC_URL, arguments={})
 
         direct_s3_mode = False
         if direct_s3_mode:
@@ -1017,7 +1016,7 @@ Example usage:
         else:
             load_stac_kwargs = {}
 
-        source_id = DataSource.load_stac(load_stac_dummy_url, properties={}, bands=[], env=env).get_source_id()
+        source_id = DataSource.load_stac(DUMMY_STAC_URL, properties={}, bands=[], env=env).get_source_id()
         load_params = _extract_load_parameters(env, source_id=source_id)
 
         env = env.push(

--- a/openeogeotrellis/constants.py
+++ b/openeogeotrellis/constants.py
@@ -21,3 +21,6 @@ JOB_OPTION_LOGGING_THRESHOLD = "logging-threshold"  # Deprecated in favor of JOB
 
 
 STAC_API_FILTER_BY_GEOMETRY_DEFAULT = True
+
+# ".invalid" is a reserved TLD, so it can't collide with a real STAC URL.
+DUMMY_STAC_URL = "https://dummy.invalid/"


### PR DESCRIPTION
This is to avoid a huge stac dump each CWL job:
```
WARNING:openeo_driver.dry_run:Dry-run load_stac: failed to parse cube metadata from 'dummy' (FileNotFoundError(2, 'No such file or directory')). Falling back on generic metadata.
WARNING:openeogeotrellis.backend:post_dry_run failed: Failed to extract spatial extent from source_id=SourceId(process_id='load_stac', arguments=('dummy', (), ()), pg_node_id=None) with constraint={}: e=FileNotFoundError(2, 'No such file or directory')
Traceback (most recent call last):
  File "/home/emile/openeo/openeo-geopyspark-driver/openeogeotrellis/_backend/post_dry_run.py", line 465, in determine_global_extent
    aligned_extent_result = _extract_spatial_extent_from_constraint((source_id, constraint), catalog=catalog)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/openeo-geopyspark-driver/openeogeotrellis/_backend/post_dry_run.py", line 221, in _extract_spatial_extent_from_constraint
    return _extract_spatial_extent_from_constraint_load_stac(stac_url=url, constraint=constraint)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/openeo-geopyspark-driver/openeogeotrellis/_backend/post_dry_run.py", line 302, in _extract_spatial_extent_from_constraint_load_stac
    item_collection, _, _, _ = openeogeotrellis.load_stac.construct_item_collection(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/openeo-geopyspark-driver/openeogeotrellis/load_stac.py", line 980, in construct_item_collection
    stac_object = _await_stac_object(
                  ^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/openeo-geopyspark-driver/openeogeotrellis/load_stac.py", line 2545, in _await_stac_object
    stac_object = pystac.read_file(href=url, stac_io=stac_io)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/venv_311/lib/python3.11/site-packages/pystac/__init__.py", line 170, in read_file
    return stac_io.read_stac_object(href)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/venv_311/lib/python3.11/site-packages/pystac/stac_io.py", line 235, in read_stac_object
    d = self.read_json(source, *args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/venv_311/lib/python3.11/site-packages/pystac/stac_io.py", line 206, in read_json
    txt = self.read_text(source, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/venv_311/lib/python3.11/site-packages/pystac/stac_io.py", line 283, in read_text
    return self.read_text_from_href(href)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/openeo-geopyspark-driver/openeogeotrellis/integrations/stac.py", line 211, in read_text_from_href
    return super().read_text_from_href(href)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/venv_311/lib/python3.11/site-packages/pystac/stac_io.py", line 327, in read_text_from_href
    with open(href, encoding="utf-8") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'dummy'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/emile/openeo/openeo-geopyspark-driver/openeogeotrellis/backend.py", line 1388, in post_dry_run
    post_dry_run_data = openeogeotrellis._backend.post_dry_run.post_dry_run(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/openeo-geopyspark-driver/openeogeotrellis/_backend/post_dry_run.py", line 495, in post_dry_run
    global_extent = determine_global_extent(source_constraints=source_constraints, catalog=catalog)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/emile/openeo/openeo-geopyspark-driver/openeogeotrellis/_backend/post_dry_run.py", line 467, in determine_global_extent
    raise SpatialExtentExtractionError(
openeogeotrellis._backend.post_dry_run.SpatialExtentExtractionError: Failed to extract spatial extent from source_id=SourceId(process_id='load_stac', arguments=('dummy', (), ()), pg_node_id=None) with constraint={}: e=FileNotFoundError(2, 'No such file or directory')
```
An other compare with "dummy": https://github.com/ESA-APEx/apex_algorithms/blob/f9ba9c335b691eb313ee84dbc54770721edd492e/qa/benchmarks/tests/conftest.py#L71