### PR TITLE
credit-plans: default to empty list

### DIFF
--- a/openeogeotrellis/integrations/credit_check.py
+++ b/openeogeotrellis/integrations/credit_check.py
@@ -77,8 +77,6 @@ class CreditCheck(ABC):
         valid. Implementation classes should call this super method first and then perform their additional checks.
         """
         if isinstance(user_provided_plans, list):
-            if len(user_provided_plans) == 0:
-                self._raise_invalid_plan(f"Plan should be a list of strings with at least 1 plan got 0 plans.")
             for plan in user_provided_plans:
                 if not isinstance(plan, str):
                     self._raise_invalid_plan(f"Plan should be a list of strings got a list containing {type(plan)}")

--- a/openeogeotrellis/job_options.py
+++ b/openeogeotrellis/job_options.py
@@ -159,7 +159,7 @@ class JobOptions:
     )
 
     credit_plans: List[str] = field(
-        default=None,
+        default_factory=list,
         metadata={
             "description": get_backend_config().credit_check.get_job_option_description(),
             "experimental": True,
@@ -220,8 +220,7 @@ class JobOptions:
                     self._log.warning(f"Invalid value {self.image_name} for job_option image-name")
                     #raise OpenEOApiException(f"Invalid value {self.image_name} for job_option image-name", status_code=400)
 
-        # Web-editor does not respect default of None but replaces it with []
-        if self.credit_plans is not None and len(self.credit_plans) > 0:
+        if len(self.credit_plans) > 0:
             get_backend_config().credit_check.check_format_user_provided_plans(self.credit_plans)
 
     def soft_errors_arg(self) -> str:

--- a/tests/integrations/test_credit_check.py
+++ b/tests/integrations/test_credit_check.py
@@ -45,12 +45,6 @@ class TestCreditCheckFormatValidation:
         # Should not raise
         self.credit_check.check_format_user_provided_plans(["plan-a", "plan-b"])
 
-    def test_empty_list_raises(self):
-        with pytest.raises(OpenEOApiException) as exc_info:
-            self.credit_check.check_format_user_provided_plans([])
-        assert exc_info.value.status_code == 400
-        assert exc_info.value.code == "CreditPlansInvalid"
-
     @pytest.mark.parametrize("invalid_input", ["plan-a", 123, {"plan": "x"}, None])
     def test_non_list_raises(self, invalid_input):
         with pytest.raises(OpenEOApiException) as exc_info:
@@ -60,7 +54,7 @@ class TestCreditCheckFormatValidation:
 
     def test_error_message_contains_job_option_name(self):
         with pytest.raises(OpenEOApiException) as exc_info:
-            self.credit_check.check_format_user_provided_plans([])
+            self.credit_check.check_format_user_provided_plans("invalidInput")
         assert JOB_OPTION_CREDIT_PLANS in exc_info.value.message
 
 

--- a/tests/test_job_options.py
+++ b/tests/test_job_options.py
@@ -1,4 +1,6 @@
 import json
+import typing
+from dataclasses import fields
 
 import pytest
 
@@ -139,14 +141,37 @@ def test_list_options_with_public_only():
     assert all(option.get("public", True) for option in options)
 
 
+def test_mutable_job_options_do_not_have_none_as_default():
+    """
+    The webeditor looks at JSON schemas for options and will provide
+    an empty list/dict if the schema is list or dict rather than the default None
+    specified in the option. This is a safeguard against bugs due to unexpected values.
+    """
+
+    def is_list_type(t) -> bool:
+        return typing.get_origin(t) is list or t is list
+
+    def is_dict_type(t) -> bool:
+        return typing.get_origin(t) is dict or t is dict
+
+    for field in fields(JobOptions):
+        if is_list_type(field.type) or is_dict_type(field.type):
+            assert field.default is not None, f"{field.name} should not have default of None"
+
+
 class TestCreditPlansJobOption:
+    @staticmethod
+    def assert_is_emtpy_list(item):
+        assert len(item) == 0
+        assert isinstance(item, list)
+
     def test_credit_plans_parsed(self):
         job_options = JobOptions.from_dict({JOB_OPTION_CREDIT_PLANS: ["plan-a"]})
         assert job_options.credit_plans == ["plan-a"]
 
-    def test_credit_plans_absent_is_none(self):
+    def test_credit_plans_absent_is_empty_list(self):
         job_options = JobOptions.from_dict({})
-        assert job_options.credit_plans is None
+        self.assert_is_emtpy_list(job_options.credit_plans)
 
     def test_credit_plans_empty_list_does_not_raises(self):
         """
@@ -155,8 +180,7 @@ class TestCreditPlansJobOption:
         """
         options = JobOptions.from_dict({JOB_OPTION_CREDIT_PLANS: []})
         options.validate()
-        assert len(options.credit_plans) == 0
-        assert isinstance(options.credit_plans, list)
+        self.assert_is_emtpy_list(options.credit_plans)
 
     def test_credit_plans_multiple_plans_accepted(self):
         job_options = JobOptions.from_dict({JOB_OPTION_CREDIT_PLANS: ["plan-a", "plan-b"]})


### PR DESCRIPTION
tests: do not allow default of None for JobOptions with mutable types