### PR TITLE
Make kafka an optional dependency for now #1804

### DIFF
--- a/openeogeotrellis/async_task.py
+++ b/openeogeotrellis/async_task.py
@@ -7,7 +7,6 @@ import time
 from subprocess import Popen, PIPE
 from typing import List, Optional
 
-import kafka
 import kazoo.client
 from py4j.java_gateway import OutputConsumer, ProcessConsumer
 from py4j.clientserver import ClientServer, JavaParameters
@@ -70,6 +69,11 @@ def _schedule_task(task_id: str, arguments: dict, job_id: str, user_id: str):
 
     def encode(s: str) -> bytes:
         return s.encode('utf-8')
+
+    # For now: make kafka an optional dependency.
+    # Long term: drop kafka/async_task feature as a whole
+    # also see https://github.com/Open-EO/openeo-geopyspark-driver/issues/1804
+    import kafka
 
     producer = kafka.KafkaProducer(
         bootstrap_servers=config.async_tasks_kafka_bootstrap_servers,

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ tests_require = [
     "zarr",
     "jsonschema",
     "rioxarray",
+    "kafka-python==1.4.6",  # TODO get rid of this https://github.com/Open-EO/openeo-geopyspark-driver/issues/1804
     # TODO: GDAL (aka osgeo.gdal) should be listed here. See https://github.com/Open-EO/openeo-geopyspark-driver/issues/1363
 ] + yarn_require
 
@@ -113,7 +114,6 @@ setup(
         "python-json-logger~=2.0",  # Avoid breaking change in 3.1.0 https://github.com/nhairs/python-json-logger/issues/29
         'jep==4.1.1; python_version<"3.9"',
         'jep_openeo_numpy==4.1.2; python_version>="3.9"',  # Required because Jep needs to compile against numpy 2.x
-        'kafka-python==1.4.6',
         'deprecated>=1.2.12',
         'elasticsearch==7.16.3',
         "pystac>=1.8.4",
@@ -140,6 +140,9 @@ setup(
         "spark4": ["pyspark>=4.0.0,<5.0.0"],
         # "extras" trick to allow pinning down on pyspark 4.0.x for particular CI contexts
         "spark40x": ["pyspark~=4.0.0"],
+        "kafka": [
+            "kafka-python==1.4.6"
+        ],  # TODO get rid of this https://github.com/Open-EO/openeo-geopyspark-driver/issues/1804
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION

first step to remove kafka dependency (#1804) : make it optional

(more simple alternative for full removal from #1805  )